### PR TITLE
Refactor: Protocol encoder

### DIFF
--- a/src/graph_models/gql/conversions.cc
+++ b/src/graph_models/gql/conversions.cc
@@ -177,8 +177,11 @@ std::string Conversions::to_lexical_str(ObjectId oid)
     case GQL_OID::Type::PATH: {
         std::stringstream ss;
         ss << '[';
-        // TODO:
-        // path_manager.print(ss, Conversions::get_path_id(oid), &print_path_node, &print_path_edge);
+        path_manager.for_each(
+            Conversions::get_path_id(oid),
+            [&](ObjectId oid) { print_path_node(ss, oid); },
+            [&](ObjectId oid, bool reverse) { print_path_edge(ss, oid, reverse); }
+        );
         ss << ']';
         return ss.str();
     }

--- a/src/graph_models/gql/conversions.cc
+++ b/src/graph_models/gql/conversions.cc
@@ -177,7 +177,8 @@ std::string Conversions::to_lexical_str(ObjectId oid)
     case GQL_OID::Type::PATH: {
         std::stringstream ss;
         ss << '[';
-        path_manager.print(ss, Conversions::get_path_id(oid), &print_path_node, &print_path_edge);
+        // TODO:
+        // path_manager.print(ss, Conversions::get_path_id(oid), &print_path_node, &print_path_edge);
         ss << ']';
         return ss.str();
     }

--- a/src/graph_models/rdf_model/conversions.cc
+++ b/src/graph_models/rdf_model/conversions.cc
@@ -415,13 +415,11 @@ std::string Conversions::to_lexical_str(ObjectId oid) {
     case RDF_OID::Type::PATH: {
         std::stringstream ss;
         ss << '[';
-        // TODO:
-        // path_manager.print(
-        //     ss,
-        //     Conversions::get_path_id(oid),
-        //     &print_path_node,
-        //     &print_path_edge
-        // );
+        path_manager.for_each(
+            Conversions::get_path_id(oid),
+            [&](ObjectId oid) { print_path_node(ss, oid); },
+            [&](ObjectId oid, bool reverse) { print_path_edge(ss, oid, reverse); }
+        );
         ss << ']';
         return ss.str();
     }
@@ -544,13 +542,11 @@ std::ostream& Conversions::debug_print(std::ostream& os, ObjectId oid) {
     case RDF_OID::Type::PATH: {
         using namespace std::placeholders;
         os << '[';
-        // TODO:
-        // path_manager.print(
-        //     os,
-        //     Conversions::get_path_id(oid),
-        //     std::bind(&print_path_node, _1, _2),
-        //     std::bind(&print_path_edge, _1, _2, _3)
-        // );
+        path_manager.for_each(
+            Conversions::get_path_id(oid),
+            [&](ObjectId oid) { print_path_node(os, oid); },
+            [&](ObjectId oid, bool reverse) { print_path_edge(os, oid, reverse); }
+        );
         os << ']';
         break;
     }

--- a/src/graph_models/rdf_model/conversions.cc
+++ b/src/graph_models/rdf_model/conversions.cc
@@ -415,12 +415,13 @@ std::string Conversions::to_lexical_str(ObjectId oid) {
     case RDF_OID::Type::PATH: {
         std::stringstream ss;
         ss << '[';
-        path_manager.print(
-            ss,
-            Conversions::get_path_id(oid),
-            &print_path_node,
-            &print_path_edge
-        );
+        // TODO:
+        // path_manager.print(
+        //     ss,
+        //     Conversions::get_path_id(oid),
+        //     &print_path_node,
+        //     &print_path_edge
+        // );
         ss << ']';
         return ss.str();
     }
@@ -543,12 +544,13 @@ std::ostream& Conversions::debug_print(std::ostream& os, ObjectId oid) {
     case RDF_OID::Type::PATH: {
         using namespace std::placeholders;
         os << '[';
-        path_manager.print(
-            os,
-            Conversions::get_path_id(oid),
-            std::bind(&print_path_node, _1, _2),
-            std::bind(&print_path_edge, _1, _2, _3)
-        );
+        // TODO:
+        // path_manager.print(
+        //     os,
+        //     Conversions::get_path_id(oid),
+        //     std::bind(&print_path_node, _1, _2),
+        //     std::bind(&print_path_edge, _1, _2, _3)
+        // );
         os << ']';
         break;
     }

--- a/src/network/server/session/streaming/response/streaming_gql_response_writer.h
+++ b/src/network/server/session/streaming/response/streaming_gql_response_writer.h
@@ -22,45 +22,42 @@ public:
         return GQLCatalog::MAJOR_VERSION;
     }
 
-    std::string encode_path_edge(ObjectId edge_id, ObjectId direction_id) const
+    void write_dictionary_key(const ObjectId& oid) override
     {
-        std::string direction;
+        std::stringstream ss;
+        ss << oid;
+        write_typed_string(ss.str(), Protocol::DataType::STRING);
+    }
 
+    void write_gql_path_edge(ObjectId edge_id, ObjectId direction_id)
+    {
         switch (direction_id.id) {
         case ObjectId::DIRECTION_LEFT:
-            direction = "left";
+            write_string_raw("left");
             break;
         case ObjectId::DIRECTION_RIGHT:
-            direction = "right";
+            write_string_raw("right");
             break;
         case ObjectId::DIRECTION_UNDIRECTED:
-            direction = "undirected";
+            write_string_raw("undirected");
             break;
         }
 
-        std::string res;
-        res += encode_size(direction.size());
-        res += direction;
-        res += encode_object_id(edge_id);
-        return res;
+        write_object_id(edge_id);
     }
 
-    std::string encode_gql_path(const ObjectId& oid) const
+    void write_gql_path(const ObjectId& oid)
     {
         std::vector<ObjectId> path;
         GQL::Conversions::unpack_path(oid, path);
 
-        GQL::Conversions::debug_print(std::cout, oid);
-        std::cout << std::endl;
+        const uint32_t path_length = path.size() / 3;
 
-        std::string res;
-        uint32_t path_length = path.size() / 3;
-
-        res += static_cast<char>(Protocol::DataType::PATH);
-        res += encode_size(path_length);
+        response_ostream.put(static_cast<char>(Protocol::DataType::PATH));
+        write_size(path_length);
 
         auto it = path.begin();
-        res += encode_object_id(*it);
+        write_object_id(*it);
         it++;
 
         while (it != path.end()) {
@@ -68,121 +65,120 @@ public:
             it++;
             ObjectId direction_id = *it;
             it++;
-            res += encode_path_edge(edge_id, direction_id);
-            res += encode_object_id(*it);
+            write_gql_path_edge(edge_id, direction_id);
+            write_object_id(*it);
             it++;
         }
-        return res;
     }
 
-    std::string encode_list(const ObjectId& oid) const
-    {
-        std::vector<ObjectId> oid_list;
-        GQL::Conversions::unpack_list(oid, oid_list);
-
-        std::string res;
-        res += static_cast<char>(Protocol::DataType::LIST);
-        res += encode_size(oid_list.size());
-
-        for (auto it = oid_list.begin(); it != oid_list.end(); ++it) {
-            res += encode_object_id(*it);
-        }
-        return res;
-    }
-
-    std::string encode_dictionary_key(const ObjectId& oid) const override
-    {
-        std::stringstream ss;
-        ss << oid;
-        return encode_string(ss.str(), Protocol::DataType::STRING);
-    }
-
-    std::string encode_object_id(const ObjectId& oid) const override
+    void write_object_id(const ObjectId& oid) override
     {
         const auto type = GQL_OID::get_type(oid);
         const auto value = oid.get_value();
 
         switch (type) {
         case GQL_OID::Type::NULL_ID: {
-            return encode_null();
+            write_null();
+            break;
         }
         case GQL_OID::Type::STRING_SIMPLE_INLINE:
         case GQL_OID::Type::STRING_SIMPLE_EXTERN:
         case GQL_OID::Type::STRING_SIMPLE_TMP: {
-            return encode_string(GQL::Conversions::unpack_string(oid), Protocol::DataType::STRING);
+            write_typed_string(GQL::Conversions::unpack_string(oid), Protocol::DataType::STRING);
+            break;
         }
         case GQL_OID::Type::INT56_INLINE:
         case GQL_OID::Type::INT64_EXTERN:
         case GQL_OID::Type::INT64_TMP: {
             const int64_t i = GQL::Conversions::unpack_int(oid);
-            return encode_int64(i);
+            write_int64(i);
+            break;
         }
         case GQL_OID::Type::FLOAT32: {
             const int64_t f = GQL::Conversions::unpack_float(oid);
-            return encode_float(f);
+            write_float(f);
+            break;
         }
         case GQL_OID::Type::DOUBLE64_EXTERN:
         case GQL_OID::Type::DOUBLE64_TMP: {
             const double d = GQL::Conversions::unpack_double(oid);
-            return encode_double(d);
+            write_double(d);
+            break;
         }
         case GQL_OID::Type::DECIMAL_INLINE:
         case GQL_OID::Type::DECIMAL_EXTERN:
         case GQL_OID::Type::DECIMAL_TMP: {
             const Decimal dec = GQL::Conversions::unpack_decimal(oid);
-            return encode_string(dec.to_string(), Protocol::DataType::DECIMAL);
+            write_typed_string(dec.to_string(), Protocol::DataType::DECIMAL);
+            break;
         }
         case GQL_OID::Type::DATE: {
             const DateTime datetime = GQL::Conversions::unpack_date(oid);
-            return encode_date(datetime);
+            write_date(datetime);
+            break;
         }
         case GQL_OID::Type::TIME: {
             const DateTime datetime = GQL::Conversions::unpack_date(oid);
-            return encode_time(datetime);
+            write_time(datetime);
+            break;
         }
         case GQL_OID::Type::DATETIME:
         case GQL_OID::Type::DATETIMESTAMP: {
             const DateTime datetime = GQL::Conversions::unpack_date(oid);
-            return encode_datetime(datetime);
+            write_datetime(datetime);
+            break;
         }
         case GQL_OID::Type::BOOL: {
             const auto b = GQL::Conversions::unpack_bool(oid);
-            return encode_bool(b);
+            write_bool(b);
+            break;
         }
         case GQL_OID::Type::PATH: {
-            return encode_gql_path(oid);
+            write_gql_path(oid);
+            break;
         }
         case GQL_OID::Type::NODE: {
-            return encode_string("_n" + std::to_string(value), Protocol::DataType::NAMED_NODE);
+            write_typed_string("_n" + std::to_string(value), Protocol::DataType::NAMED_NODE);
+            break;
         }
-        case GQL_OID::Type::DIRECTED_EDGE: {
-            return encode_string("_e" + std::to_string(value), Protocol::DataType::EDGE);
-        }
+        case GQL_OID::Type::DIRECTED_EDGE:
         case GQL_OID::Type::UNDIRECTED_EDGE: {
-            return encode_string("_u" + std::to_string(value), Protocol::DataType::EDGE);
+            write_edge(value);
+            break;
         }
         case GQL_OID::Type::NODE_LABEL: {
-            return encode_string(gql_model.catalog.node_labels_str[value], Protocol::DataType::STRING);
+            write_typed_string(gql_model.catalog.node_labels_str[value], Protocol::DataType::STRING);
+            break;
         }
         case GQL_OID::Type::EDGE_LABEL: {
-            return encode_string(gql_model.catalog.edge_labels_str[value], Protocol::DataType::STRING);
+            write_typed_string(gql_model.catalog.edge_labels_str[value], Protocol::DataType::STRING);
+            break;
         }
         case GQL_OID::Type::NODE_KEY: {
-            return encode_string(gql_model.catalog.node_keys_str[value], Protocol::DataType::STRING);
+            write_typed_string(gql_model.catalog.node_keys_str[value], Protocol::DataType::STRING);
+            break;
         }
         case GQL_OID::Type::EDGE_KEY: {
-            return encode_string(gql_model.catalog.edge_keys_str[value], Protocol::DataType::STRING);
+            write_typed_string(gql_model.catalog.edge_keys_str[value], Protocol::DataType::STRING);
+            break;
         }
         case GQL_OID::Type::DICTIONARY: {
             std::unique_ptr<Dictionary> dictionary;
             Common::Conversions::unpack_dictionary(oid, dictionary);
-            return encode_dictionary(*dictionary);
+            write_dictionary(*dictionary);
+            break;
         }
         case GQL_OID::Type::LIST: {
-            return encode_list(oid);
+            std::vector<ObjectId> oid_list;
+            GQL::Conversions::unpack_list(oid, oid_list);
+            write_list(oid_list);
+            break;
         }
         default: {
-            return encode_null();
+            throw std::logic_error(
+                "Unmanaged type in StreamingGQLResponseWriter::encode_object_id: "
+                + std::to_string(static_cast<uint8_t>(type))
+            );
         }
         }
     }

--- a/src/network/server/session/streaming/response/streaming_quad_response_writer.h
+++ b/src/network/server/session/streaming/response/streaming_quad_response_writer.h
@@ -22,115 +22,112 @@ public:
         return QuadCatalog::MAJOR_VERSION;
     }
 
-    std::string encode_list(const ObjectId& oid) const
+    void write_dictionary_key(const ObjectId& oid) override
     {
-        std::vector<ObjectId> oid_list = MQL::Conversions::unpack_list(oid);
-
-        std::string res;
-        res += static_cast<char>(Protocol::DataType::LIST);
-        res += encode_size(oid_list.size());
-
-        for (auto it = oid_list.begin(); it != oid_list.end(); ++it) {
-            res += encode_object_id(*it);
-        }
-        return res;
+        const auto str = MQL::Conversions::to_lexical_str(oid);
+        write_typed_string(str, Protocol::DataType::STRING);
     }
 
-    std::string encode_dictionary_key(const ObjectId& oid) const override
-    {
-        auto str = MQL::Conversions::to_lexical_str(oid);
-        return encode_string(str, Protocol::DataType::STRING);
-    }
-
-    std::string encode_object_id(const ObjectId& oid) const override
+    void write_object_id(const ObjectId& oid) override
     {
         const auto type = oid.get_type();
         const auto value = oid.get_value();
         switch (type) {
         case ObjectId::MASK_NULL: {
-            return encode_null();
+            write_null();
+            break;
         }
-        case ObjectId::MASK_ANON_INLINED: {
-            const auto anon_id = MQL::Conversions::unpack_blank(oid);
-            return encode_string("_a" + std::to_string(anon_id), Protocol::DataType::ANON);
-        }
+        case ObjectId::MASK_ANON_INLINED:
         case ObjectId::MASK_ANON_TMP: {
             const auto anon_id = MQL::Conversions::unpack_blank(oid);
-            return encode_string("_c" + std::to_string(anon_id), Protocol::DataType::ANON);
+            write_anon(anon_id);
+            break;
         }
         case ObjectId::MASK_NAMED_NODE_INLINED:
         case ObjectId::MASK_NAMED_NODE_EXTERN:
         case ObjectId::MASK_NAMED_NODE_TMP: {
             const auto str = MQL::Conversions::unpack_named_node(oid);
-            return encode_string(str, Protocol::DataType::NAMED_NODE);
+            write_typed_string(str, Protocol::DataType::NAMED_NODE);
+            break;
         }
         case ObjectId::MASK_STRING_SIMPLE_INLINED:
         case ObjectId::MASK_STRING_SIMPLE_EXTERN:
         case ObjectId::MASK_STRING_SIMPLE_TMP: {
             const auto str = MQL::Conversions::unpack_string(oid);
-            return encode_string(str, Protocol::DataType::STRING);
+            write_typed_string(str, Protocol::DataType::STRING);
+            break;
         }
         case ObjectId::MASK_NEGATIVE_INT:
         case ObjectId::MASK_POSITIVE_INT: {
             const int64_t i = MQL::Conversions::unpack_int(oid);
-            return encode_int64(i);
+            write_int64(i);
+            break;
         }
         case ObjectId::MASK_DECIMAL_INLINED:
         case ObjectId::MASK_DECIMAL_EXTERN:
         case ObjectId::MASK_DECIMAL_TMP: {
             const Decimal dec = SPARQL::Conversions::unpack_decimal(oid);
-            return encode_string(dec.to_string(), Protocol::DataType::DECIMAL);
+            write_typed_string(dec.to_string(), Protocol::DataType::DECIMAL);
+            break;
         }
         case ObjectId::MASK_FLOAT: {
             const float f = MQL::Conversions::unpack_float(oid);
-            return encode_float(f);
+            write_float(f);
+            break;
         }
         case ObjectId::MASK_BOOL: {
-            return encode_bool(value != 0);
+            write_bool(value != 0);
+            break;
         }
         case ObjectId::MASK_EDGE: {
             const auto edge_id = MQL::Conversions::unpack_edge(oid);
-            return encode_edge(edge_id);
+            write_edge(edge_id);
+            break;
         }
         case ObjectId::MASK_DT_DATE: {
             const DateTime datetime = MQL::Conversions::unpack_datetime(oid);
-            return encode_date(datetime);
+            write_date(datetime);
+            break;
         }
         case ObjectId::MASK_DT_TIME: {
             const DateTime datetime = MQL::Conversions::unpack_datetime(oid);
-            return encode_time(datetime);
+            write_time(datetime);
+            break;
         }
         case ObjectId::MASK_DT_DATETIME:
         case ObjectId::MASK_DT_DATETIMESTAMP: {
             const DateTime datetime = MQL::Conversions::unpack_datetime(oid);
-            return encode_datetime(datetime);
+            write_datetime(datetime);
+            break;
         }
         case ObjectId::MASK_PATH: {
-            return encode_path(value);
+            write_path(value);
+            break;
         }
         case ObjectId::MASK_TENSOR_FLOAT_INLINED:
         case ObjectId::MASK_TENSOR_FLOAT_EXTERN:
         case ObjectId::MASK_TENSOR_FLOAT_TMP: {
             const auto tensor = Common::Conversions::unpack_tensor<float>(oid);
-            return encode_tensor<float>(tensor);
+            write_tensor<float>(tensor);
+            break;
         }
         case ObjectId::MASK_TENSOR_DOUBLE_INLINED:
         case ObjectId::MASK_TENSOR_DOUBLE_EXTERN:
         case ObjectId::MASK_TENSOR_DOUBLE_TMP: {
             const auto tensor = Common::Conversions::unpack_tensor<double>(oid);
-            return encode_tensor<double>(tensor);
+            write_tensor<double>(tensor);
+            break;
         }
         case ObjectId::MASK_DICTIONARY:
         case ObjectId::MASK_DICTIONARY_TMP: {
-            std::unique_ptr<Dictionary> dictionary;
-            Common::Conversions::unpack_dictionary(oid, dictionary);
-            return encode_dictionary(*dictionary);
+            const auto dictionary = Common::Conversions::unpack_dictionary(oid);
+            write_dictionary(*dictionary);
         }
         case ObjectId::MASK_LIST:
         case ObjectId::MASK_LIST_EXTERN:
         case ObjectId::MASK_LIST_TMP: {
-            std::vector<ObjectId> list = MQL::Conversions::unpack_list(oid);
-            return encode_list(oid);
+            const auto list = MQL::Conversions::unpack_list(oid);
+            return write_list(list);
         }
         default:
             throw std::logic_error(

--- a/src/network/server/session/streaming/response/streaming_rdf_response_writer.h
+++ b/src/network/server/session/streaming/response/streaming_rdf_response_writer.h
@@ -2,7 +2,6 @@
 
 #include "streaming_response_writer.h"
 
-#include "graph_models/rdf_model/rdf_model.h"
 #include "graph_models/rdf_model/conversions.h"
 #include "graph_models/rdf_model/rdf_catalog.h"
 #include "graph_models/rdf_model/rdf_object_id.h"
@@ -21,35 +20,28 @@ public:
         return RdfCatalog::MAJOR_VERSION;
     }
 
-    std::string encode_string_lang(const std::string& str, const std::string& lang) const {
-        std::string res;
-        res += static_cast<char>(Protocol::DataType::STRING_LANG);
-        res += encode_size(str.size());
-        res += str;
-        res += encode_size(lang.size());
-        res += lang;
-        return res;
+    void write_string_lang(const std::string& str, const std::string& lang)
+    {
+        write_typed_string(str, Protocol::DataType::STRING_LANG);
+        write_string_raw(lang);
     }
 
-    std::string encode_string_datatype(const std::string& str, const std::string& datatype) const {
-        std::string res;
-        res += static_cast<char>(Protocol::DataType::STRING_DATATYPE);
-        res += encode_size(str.size());
-        res += str;
-        res += encode_size(datatype.size());
-        res += datatype;
-        return res;
+    void write_string_datatype(const std::string& str, const std::string& datatype)
+    {
+        write_typed_string(str, Protocol::DataType::STRING_DATATYPE);
+        write_string_raw(datatype);
     }
 
-    std::string encode_object_id(const ObjectId& oid) const override {
+    void write_object_id(const ObjectId& oid) override
+    {
         const auto type  = RDF_OID::get_type(oid);
         const auto value = oid.get_value();
         switch (type) {
-        case RDF_OID::Type::BLANK_INLINED: {
-            return encode_string("_:b" + std::to_string(value), Protocol::DataType::ANON);
-        }
+        case RDF_OID::Type::BLANK_INLINED:
         case RDF_OID::Type::BLANK_TMP: {
-            return encode_string("_:c" + std::to_string(value), Protocol::DataType::ANON);
+            const auto blank_id = SPARQL::Conversions::unpack_blank(oid);
+            write_anon(blank_id);
+            break;
         }
         case RDF_OID::Type::STRING_SIMPLE_INLINE:
         case RDF_OID::Type::STRING_SIMPLE_EXTERN:
@@ -58,82 +50,98 @@ public:
         case RDF_OID::Type::STRING_XSD_EXTERN:
         case RDF_OID::Type::STRING_XSD_TMP: {
             const auto str = SPARQL::Conversions::unpack_string(oid);
-            return encode_string(str, Protocol::DataType::STRING);
+            write_typed_string(str, Protocol::DataType::STRING);
+            break;
         }
         case RDF_OID::Type::INT56_INLINE:
         case RDF_OID::Type::INT64_EXTERN:
         case RDF_OID::Type::INT64_TMP: {
             const int64_t i = SPARQL::Conversions::unpack_int(oid);
-            return encode_int64(i);
+            write_int64(i);
+            break;
         }
         case RDF_OID::Type::FLOAT32: {
             const float f = SPARQL::Conversions::unpack_float(oid);
-            return encode_float(f);
+            write_float(f);
+            break;
         }
         case RDF_OID::Type::DOUBLE64_EXTERN:
         case RDF_OID::Type::DOUBLE64_TMP: {
             const double d = SPARQL::Conversions::unpack_double(oid);
-            return encode_double(d);
+            write_double(d);
+            break;
         }
         case RDF_OID::Type::BOOL: {
             const auto b = SPARQL::Conversions::unpack_bool(oid);
-            return encode_bool(b);
+            write_bool(b);
+            break;
         }
         case RDF_OID::Type::PATH: {
-            return encode_path(value);
+            write_path(value);
+            break;
         }
         case RDF_OID::Type::IRI_INLINE:
         case RDF_OID::Type::IRI_INLINE_INT_SUFFIX:
         case RDF_OID::Type::IRI_EXTERN:
         case RDF_OID::Type::IRI_TMP: {
             const auto iri = SPARQL::Conversions::unpack_iri(oid);
-            return encode_string(iri, Protocol::DataType::IRI);
+            write_typed_string(iri, Protocol::DataType::IRI);
+            break;
         }
         case RDF_OID::Type::STRING_DATATYPE_INLINE:
         case RDF_OID::Type::STRING_DATATYPE_EXTERN:
         case RDF_OID::Type::STRING_DATATYPE_TMP: {
             const auto&& [datatype, str] = SPARQL::Conversions::unpack_string_datatype(oid);
-            return encode_string_datatype(str, datatype);
+            write_string_datatype(str, datatype);
+            break;
         }
         case RDF_OID::Type::STRING_LANG_INLINE:
         case RDF_OID::Type::STRING_LANG_EXTERN:
         case RDF_OID::Type::STRING_LANG_TMP: {
             const auto&& [lang, str] = SPARQL::Conversions::unpack_string_lang(oid);
-            return encode_string_lang(str, lang);
+            write_string_lang(str, lang);
+            break;
         }
         case RDF_OID::Type::DATE: {
             const DateTime datetime = SPARQL::Conversions::unpack_date(oid);
-            return encode_date(datetime);
+            write_date(datetime);
+            break;
         }
         case RDF_OID::Type::TIME: {
             const DateTime datetime = SPARQL::Conversions::unpack_date(oid);
-            return encode_time(datetime);
+            write_time(datetime);
+            break;
         }
         case RDF_OID::Type::DATETIME:
         case RDF_OID::Type::DATETIMESTAMP: {
             const DateTime datetime = SPARQL::Conversions::unpack_date(oid);
-            return encode_datetime(datetime);
+            write_datetime(datetime);
+            break;
         }
         case RDF_OID::Type::DECIMAL_INLINE:
         case RDF_OID::Type::DECIMAL_EXTERN:
         case RDF_OID::Type::DECIMAL_TMP: {
             const Decimal dec = SPARQL::Conversions::unpack_decimal(oid);
-            return encode_string(dec.to_string(), Protocol::DataType::DECIMAL);
+            write_typed_string(dec.to_string(), Protocol::DataType::DECIMAL);
+            break;
         }
         case RDF_OID::Type::NULL_ID: {
-            return encode_null();
+            write_null();
+            break;
         }
         case RDF_OID::Type::TENSOR_FLOAT_INLINE:
         case RDF_OID::Type::TENSOR_FLOAT_EXTERN:
         case RDF_OID::Type::TENSOR_FLOAT_TMP: {
             const auto tensor = Common::Conversions::unpack_tensor<float>(oid);
-            return encode_tensor<float>(tensor);
+            write_tensor<float>(tensor);
+            break;
         }
         case RDF_OID::Type::TENSOR_DOUBLE_INLINE:
         case RDF_OID::Type::TENSOR_DOUBLE_EXTERN:
         case RDF_OID::Type::TENSOR_DOUBLE_TMP: {
             const auto tensor = Common::Conversions::unpack_tensor<double>(oid);
-            return encode_tensor<double>(tensor);
+            write_tensor<double>(tensor);
+            break;
         }
         default:
             throw std::logic_error("Unmanaged type in RdfResponseWriter::encode_object_id: "

--- a/src/network/server/session/streaming/response/streaming_response_writer.cc
+++ b/src/network/server/session/streaming/response/streaming_response_writer.cc
@@ -19,23 +19,23 @@ void StreamingResponseWriter::write_variables(
 )
 {
     write_map_header(2UL);
-    write_string("type");
+    write_typed_string("type", Protocol::DataType::STRING);
     write_uint8(static_cast<uint8_t>(Protocol::ResponseType::VARIABLES));
 
-    write_string("payload");
+    write_typed_string("payload", Protocol::DataType::STRING);
     write_map_header(2UL);
-    write_string("variables");
+    write_typed_string("variables", Protocol::DataType::STRING);
     write_list_header(projection_vars.size());
     for (const auto& var_id : projection_vars) {
         const auto var_name = get_query_ctx().get_var_name(var_id);
-        write_string(var_name);
+        write_typed_string(var_name, Protocol::DataType::STRING);
     }
-    write_string("queryPreamble");
+    write_typed_string("queryPreamble", Protocol::DataType::STRING);
     write_map_header(2UL);
-    write_string("workerIndex");
+    write_typed_string("workerIndex", Protocol::DataType::STRING);
     write_uint32(worker_idx);
-    write_string("cancellationToken");
-    write_string(cancellation_token);
+    write_typed_string("cancellationToken", Protocol::DataType::STRING);
+    write_typed_string(cancellation_token, Protocol::DataType::STRING);
 
     seal();
 }
@@ -48,20 +48,20 @@ void StreamingResponseWriter::write_records_success(
 )
 {
     write_map_header(2UL);
-    write_string("type");
+    write_typed_string("type", Protocol::DataType::STRING);
     write_uint8(static_cast<uint8_t>(Protocol::ResponseType::SUCCESS));
 
-    write_string("payload");
+    write_typed_string("payload", Protocol::DataType::STRING);
     write_map_header(5UL);
-    write_string("update");
+    write_typed_string("update", Protocol::DataType::STRING);
     write_bool(false);
-    write_string("resultCount");
+    write_typed_string("resultCount", Protocol::DataType::STRING);
     write_uint64(result_count);
-    write_string("parserDurationMs");
+    write_typed_string("parserDurationMs", Protocol::DataType::STRING);
     write_double(parser_duration_ms);
-    write_string("optimizerDurationMs");
+    write_typed_string("optimizerDurationMs", Protocol::DataType::STRING);
     write_double(optimizer_duration_ms);
-    write_string("executionDurationMs");
+    write_typed_string("executionDurationMs", Protocol::DataType::STRING);
     write_double(execution_duration_ms);
 
     seal();
@@ -74,19 +74,19 @@ void StreamingResponseWriter::write_update_success(
 )
 {
     write_map_header(2UL);
-    write_string("type");
+    write_typed_string("type", Protocol::DataType::STRING);
     write_uint8(static_cast<uint8_t>(Protocol::ResponseType::SUCCESS));
 
-    write_string("payload");
+    write_typed_string("payload", Protocol::DataType::STRING);
     write_map_header(4UL);
 
-    write_string("update");
+    write_typed_string("update", Protocol::DataType::STRING);
     write_bool(true);
-    write_string("parserDurationMs");
+    write_typed_string("parserDurationMs", Protocol::DataType::STRING);
     write_double(parser_duration_ms);
-    write_string("optimizerDurationMs");
+    write_typed_string("optimizerDurationMs", Protocol::DataType::STRING);
     write_double(optimizer_duration_ms);
-    write_string("executionDurationMs");
+    write_typed_string("executionDurationMs", Protocol::DataType::STRING);
     write_double(execution_duration_ms);
 
     // TODO: Send update data
@@ -97,18 +97,18 @@ void StreamingResponseWriter::write_update_success(
 void StreamingResponseWriter::write_catalog_success()
 {
     write_map_header(2UL);
-    write_string("type");
+    write_typed_string("type", Protocol::DataType::STRING);
     write_uint8(static_cast<uint8_t>(Protocol::ResponseType::SUCCESS));
 
-    write_string("payload");
+    write_typed_string("payload", Protocol::DataType::STRING);
     write_map_header(3UL);
-    write_string("modelId");
+    write_typed_string("modelId", Protocol::DataType::STRING);
     write_uint64(get_model_id());
-    write_string("version");
+    write_typed_string("version", Protocol::DataType::STRING);
     write_uint64(get_catalog_version());
 
-    // TODO: Pass useful additional metadata about the catalog and/or database
-    write_string("metadata");
+    // // TODO: Pass useful additional metadata about the catalog and/or database
+    write_typed_string("metadata", Protocol::DataType::STRING);
     write_null();
 
     seal();
@@ -117,10 +117,10 @@ void StreamingResponseWriter::write_catalog_success()
 void StreamingResponseWriter::write_cancel_success()
 {
     write_map_header(2UL);
-    write_string("type");
+    write_typed_string("type", Protocol::DataType::STRING);
     write_uint8(static_cast<uint8_t>(Protocol::ResponseType::SUCCESS));
 
-    write_string("payload");
+    write_typed_string("payload", Protocol::DataType::STRING);
     write_null();
 
     seal();
@@ -129,10 +129,10 @@ void StreamingResponseWriter::write_cancel_success()
 void StreamingResponseWriter::write_record(const std::vector<VarId>& projection_vars, const Binding& binding)
 {
     write_map_header(2UL);
-    write_string("type");
+    write_typed_string("type", Protocol::DataType::STRING);
     write_uint8(static_cast<uint8_t>(Protocol::ResponseType::RECORD));
 
-    write_string("payload");
+    write_typed_string("payload",Protocol::DataType::STRING);
     write_list_header(projection_vars.size());
     for (const auto& var : projection_vars) {
         write_object_id(binding[var]);
@@ -144,51 +144,61 @@ void StreamingResponseWriter::write_record(const std::vector<VarId>& projection_
 void StreamingResponseWriter::write_error(const std::string& message)
 {
     write_map_header(2UL);
-    write_string("type");
+    write_typed_string("type",Protocol::DataType::STRING);
     write_uint8(static_cast<uint8_t>(Protocol::ResponseType::ERROR));
 
-    write_string("payload");
-    write_string(message);
+    write_typed_string("payload", Protocol::DataType::STRING);
+    write_typed_string(message, Protocol::DataType::STRING);
 
     seal();
 }
 
-std::string StreamingResponseWriter::encode_null() const
+void StreamingResponseWriter::write_null()
 {
-    return std::string(1, static_cast<char>(Protocol::DataType::NULL_));
+    response_ostream.put(static_cast<char>(Protocol::DataType::NULL_));
 }
 
-std::string StreamingResponseWriter::encode_bool(bool value) const
+void StreamingResponseWriter::write_bool(bool value)
 {
-    return std::string(
-        1,
+    response_ostream.put(
         static_cast<char>(value ? Protocol::DataType::BOOL_TRUE : Protocol::DataType::BOOL_FALSE)
     );
 }
 
-std::string StreamingResponseWriter::encode_uint8(uint8_t value) const
+void StreamingResponseWriter::write_uint8(uint8_t value)
 {
     uint8_t bytes[2];
     bytes[0] = static_cast<uint8_t>(Protocol::DataType::UINT8);
     bytes[1] = static_cast<uint8_t>(value);
-    return std::string(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-std::string StreamingResponseWriter::encode_float(float value_) const
+void StreamingResponseWriter::write_float(float value_)
 {
-    auto* value = reinterpret_cast<uint32_t*>(&value_);
+    auto value = reinterpret_cast<const uint32_t*>(&value_);
     uint8_t bytes[5];
     bytes[0] = static_cast<uint8_t>(Protocol::DataType::FLOAT);
     bytes[1] = static_cast<uint8_t>((*value >> 24) & 0xFF);
     bytes[2] = static_cast<uint8_t>((*value >> 16) & 0xFF);
     bytes[3] = static_cast<uint8_t>((*value >> 8) & 0xFF);
     bytes[4] = static_cast<uint8_t>(*value & 0xFF);
-    return std::string(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-std::string StreamingResponseWriter::encode_double(double value_) const
+void StreamingResponseWriter::write_float_raw(float value_)
 {
-    auto* value = reinterpret_cast<uint64_t*>(&value_);
+    auto value = reinterpret_cast<const uint32_t*>(&value_);
+    uint8_t bytes[4];
+    bytes[0] = static_cast<uint8_t>((*value >> 24) & 0xFF);
+    bytes[1] = static_cast<uint8_t>((*value >> 16) & 0xFF);
+    bytes[2] = static_cast<uint8_t>((*value >> 8) & 0xFF);
+    bytes[3] = static_cast<uint8_t>(*value & 0xFF);
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+}
+
+void StreamingResponseWriter::write_double(double value_)
+{
+    auto value = reinterpret_cast<const uint64_t*>(&value_);
     uint8_t bytes[9];
     bytes[0] = static_cast<uint8_t>(Protocol::DataType::DOUBLE);
     bytes[1] = static_cast<uint8_t>((*value >> 56) & 0xFF);
@@ -199,10 +209,31 @@ std::string StreamingResponseWriter::encode_double(double value_) const
     bytes[6] = static_cast<uint8_t>((*value >> 16) & 0xFF);
     bytes[7] = static_cast<uint8_t>((*value >> 8) & 0xFF);
     bytes[8] = static_cast<uint8_t>(*value & 0xFF);
-    return std::string(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-std::string StreamingResponseWriter::encode_uint32(uint32_t value) const
+void StreamingResponseWriter::write_double_raw(double value_)
+{
+    auto value = reinterpret_cast<const uint64_t*>(&value_);
+    uint8_t bytes[8];
+    bytes[0] = static_cast<uint8_t>((*value >> 56) & 0xFF);
+    bytes[1] = static_cast<uint8_t>((*value >> 48) & 0xFF);
+    bytes[2] = static_cast<uint8_t>((*value >> 40) & 0xFF);
+    bytes[3] = static_cast<uint8_t>((*value >> 32) & 0xFF);
+    bytes[4] = static_cast<uint8_t>((*value >> 24) & 0xFF);
+    bytes[5] = static_cast<uint8_t>((*value >> 16) & 0xFF);
+    bytes[6] = static_cast<uint8_t>((*value >> 8) & 0xFF);
+    bytes[7] = static_cast<uint8_t>(*value & 0xFF);
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+}
+
+void StreamingResponseWriter::write_string_raw(const std::string& value)
+{
+    write_size(value.size());
+    response_ostream.write(value.data(), value.size());
+}
+
+void StreamingResponseWriter::write_uint32(uint32_t value)
 {
     uint8_t bytes[5];
     bytes[0] = static_cast<uint8_t>(Protocol::DataType::UINT32);
@@ -210,10 +241,10 @@ std::string StreamingResponseWriter::encode_uint32(uint32_t value) const
     bytes[2] = static_cast<uint8_t>((value >> 16) & 0xFF);
     bytes[3] = static_cast<uint8_t>((value >> 8) & 0xFF);
     bytes[4] = static_cast<uint8_t>(value & 0xFF);
-    return std::string(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-std::string StreamingResponseWriter::encode_uint64(uint64_t value) const
+void StreamingResponseWriter::write_uint64(uint64_t value)
 {
     uint8_t bytes[9];
     bytes[0] = static_cast<uint8_t>(Protocol::DataType::UINT64);
@@ -225,10 +256,10 @@ std::string StreamingResponseWriter::encode_uint64(uint64_t value) const
     bytes[6] = static_cast<uint8_t>((value >> 16) & 0xFF);
     bytes[7] = static_cast<uint8_t>((value >> 8) & 0xFF);
     bytes[8] = static_cast<uint8_t>(value & 0xFF);
-    return std::string(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-std::string StreamingResponseWriter::encode_int64(int64_t value) const
+void StreamingResponseWriter::write_int64(int64_t value)
 {
     uint8_t bytes[9];
     bytes[0] = static_cast<uint8_t>(Protocol::DataType::INT64);
@@ -240,39 +271,49 @@ std::string StreamingResponseWriter::encode_int64(int64_t value) const
     bytes[6] = static_cast<uint8_t>((value >> 16) & 0xFF);
     bytes[7] = static_cast<uint8_t>((value >> 8) & 0xFF);
     bytes[8] = static_cast<uint8_t>(value & 0xFF);
-    return std::string(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-std::string
-    StreamingResponseWriter::encode_string(const std::string& value, Protocol::DataType data_type) const
+void StreamingResponseWriter::write_typed_string(const std::string& value, Protocol::DataType datatype)
 {
-    std::string res;
-    res += static_cast<char>(data_type);
-    res += encode_size(value.size());
-    res += value;
-    return res;
+    response_ostream.put(static_cast<char>(datatype));
+    write_size(value.size());
+    response_ostream.write(value.data(), value.size());
 }
 
-std::string StreamingResponseWriter::encode_path(uint64_t path_id) const
+void StreamingResponseWriter::write_path(uint64_t path_id)
 {
     using namespace std::placeholders;
-    uint_fast32_t path_length = 0UL;
-    std::stringstream ss;
-    path_manager.print(
-        ss,
+
+    response_ostream.put(static_cast<char>(Protocol::DataType::PATH));
+
+    std::vector<ObjectId> nodes;
+    std::vector<std::pair<ObjectId, bool>> edges;
+    path_manager.for_each(
         path_id,
-        std::bind(&StreamingResponseWriter::write_path_node, this, _1, _2),
-        std::bind(&StreamingResponseWriter::write_path_edge, this, _1, _2, _3, &path_length)
+        [&](ObjectId oid) { nodes.emplace_back(oid); },
+        [&](ObjectId oid, bool reverse) { edges.emplace_back(oid, reverse); }
     );
+    assert(nodes.size() == edges.size() + 1);
 
-    std::string res;
-    res += static_cast<char>(Protocol::DataType::PATH);
-    res += encode_size(path_length);
-    res += ss.str();
-    return res;
+    response_ostream.put(static_cast<char>(Protocol::DataType::PATH));
+    write_size(edges.size());
+
+    auto nodes_it = nodes.begin();
+    auto edges_it = edges.begin();
+
+    write_object_id(*nodes_it);
+    ++nodes_it;
+
+    while (edges_it != edges.end()) {
+        write_path_edge(edges_it->first, edges_it->second);
+        write_object_id(*nodes_it);
+        ++edges_it;
+        ++nodes_it;
+    }
 }
 
-std::string StreamingResponseWriter::encode_date(DateTime datetime) const
+void StreamingResponseWriter::write_date(DateTime datetime)
 {
     bool error;
     const int64_t year = datetime.get_year(&error);
@@ -280,17 +321,14 @@ std::string StreamingResponseWriter::encode_date(DateTime datetime) const
     const int64_t day = datetime.get_day(&error);
     const int64_t tz_min_offset = datetime.get_tz_min_offset(&error);
 
-    std::string res;
-    res += static_cast<char>(Protocol::DataType::DATE);
-    res += encode_int64_raw(year);
-    res += encode_int64_raw(month);
-    res += encode_int64_raw(day);
-    res += encode_int64_raw(error ? 0 : tz_min_offset);
-
-    return res;
+    response_ostream.put(static_cast<char>(Protocol::DataType::DATE));
+    write_int64_raw(year);
+    write_int64_raw(month);
+    write_int64_raw(day);
+    write_int64_raw(error ? 0 : tz_min_offset);
 }
 
-std::string StreamingResponseWriter::encode_time(DateTime datetime) const
+void StreamingResponseWriter::write_time(DateTime datetime)
 {
     bool error;
     const int64_t hour = datetime.get_hour(&error);
@@ -298,16 +336,14 @@ std::string StreamingResponseWriter::encode_time(DateTime datetime) const
     const int64_t second = datetime.get_second(&error);
     const int64_t tz_min_offset = datetime.get_tz_min_offset(&error);
 
-    std::string res;
-    res += static_cast<char>(Protocol::DataType::TIME);
-    res += encode_int64_raw(hour);
-    res += encode_int64_raw(minute);
-    res += encode_int64_raw(second);
-    res += encode_int64_raw(error ? 0 : tz_min_offset);
-    return res;
+    response_ostream.put(static_cast<char>(Protocol::DataType::TIME));
+    write_int64_raw(hour);
+    write_int64_raw(minute);
+    write_int64_raw(second);
+    write_int64_raw(error ? 0 : tz_min_offset);
 }
 
-std::string StreamingResponseWriter::encode_datetime(DateTime datetime) const
+void StreamingResponseWriter::write_datetime(DateTime datetime)
 {
     bool error;
     const int64_t year = datetime.get_year(&error);
@@ -318,70 +354,58 @@ std::string StreamingResponseWriter::encode_datetime(DateTime datetime) const
     const int64_t second = datetime.get_second(&error);
     const int64_t tz_min_offset = datetime.get_tz_min_offset(&error);
 
-    std::string res;
-    res += static_cast<char>(Protocol::DataType::DATETIME);
-    res += encode_int64_raw(year);
-    res += encode_int64_raw(month);
-    res += encode_int64_raw(day);
-    res += encode_int64_raw(hour);
-    res += encode_int64_raw(minute);
-    res += encode_int64_raw(second);
-    res += encode_int64_raw(error ? 0 : tz_min_offset);
-    return res;
+    response_ostream.put(static_cast<char>(Protocol::DataType::DATETIME));
+    write_int64_raw(year);
+    write_int64_raw(month);
+    write_int64_raw(day);
+    write_int64_raw(hour);
+    write_int64_raw(minute);
+    write_int64_raw(second);
+    write_int64_raw(error ? 0 : tz_min_offset);
 }
 
 template<typename T>
-std::string StreamingResponseWriter::encode_tensor(const tensor::Tensor<T>& tensor) const
+void StreamingResponseWriter::write_tensor(const tensor::Tensor<T>& tensor)
 {
-    std::string res;
-    res += static_cast<char>(Protocol::DataType::TENSOR);
+    response_ostream.put(static_cast<char>(Protocol::DataType::TENSOR));
 
     if constexpr (std::is_same_v<T, float>) {
-        res += static_cast<char>(Protocol::DataType::FLOAT);
+        response_ostream.put(static_cast<char>(Protocol::DataType::FLOAT));
     } else if constexpr (std::is_same_v<T, double>) {
-        res += static_cast<char>(Protocol::DataType::DOUBLE);
+        response_ostream.put(static_cast<char>(Protocol::DataType::DOUBLE));
     }
 
-    res += encode_size(tensor.size());
-
-    const auto data_offset = res.size();
-    res.resize(data_offset + sizeof(T) * tensor.size());
+    write_size(tensor.size());
 
     for (std::size_t i = 0; i < tensor.size(); ++i) {
-        auto dst = reinterpret_cast<uint8_t*>(res.data()) + data_offset + sizeof(T) * i;
         if constexpr (std::is_same_v<T, float>) {
-            auto src = reinterpret_cast<const uint32_t*>(tensor.data()) + i;
-            dst[0] = static_cast<uint8_t>((*src >> 24) & 0xFF);
-            dst[1] = static_cast<uint8_t>((*src >> 16) & 0xFF);
-            dst[2] = static_cast<uint8_t>((*src >> 8) & 0xFF);
-            dst[3] = static_cast<uint8_t>(*src & 0xFF);
+            write_float_raw(tensor[i]);
         } else if constexpr (std::is_same_v<T, double>) {
-            auto src = reinterpret_cast<const uint64_t*>(tensor.data()) + i;
-            dst[0] = static_cast<uint8_t>((*src >> 56) & 0xFF);
-            dst[1] = static_cast<uint8_t>((*src >> 48) & 0xFF);
-            dst[2] = static_cast<uint8_t>((*src >> 40) & 0xFF);
-            dst[3] = static_cast<uint8_t>((*src >> 32) & 0xFF);
-            dst[4] = static_cast<uint8_t>((*src >> 24) & 0xFF);
-            dst[5] = static_cast<uint8_t>((*src >> 16) & 0xFF);
-            dst[6] = static_cast<uint8_t>((*src >> 8) & 0xFF);
-            dst[7] = static_cast<uint8_t>(*src & 0xFF);
+            write_double_raw(tensor[i]);
         }
     }
-
-    return res;
 }
 
-std::string StreamingResponseWriter::encode_size(uint32_t value) const
+void StreamingResponseWriter::write_list(const std::vector<ObjectId>& list)
+{
+    response_ostream.put(static_cast<char>(Protocol::DataType::LIST));
+    write_size(list.size());
+    for (const auto& oid : list) {
+        write_object_id(oid);
+    }
+}
+
+void StreamingResponseWriter::write_size(uint32_t value)
 {
     uint8_t bytes[4];
     bytes[0] = static_cast<uint8_t>((value >> 24) & 0xFF);
     bytes[1] = static_cast<uint8_t>((value >> 16) & 0xFF);
     bytes[2] = static_cast<uint8_t>((value >> 8) & 0xFF);
     bytes[3] = static_cast<uint8_t>(value & 0xFF);
-    return std::string(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-std::string StreamingResponseWriter::encode_int64_raw(int64_t value) const
+void StreamingResponseWriter::write_int64_raw(int64_t value)
 {
     uint8_t bytes[8];
     bytes[0] = static_cast<uint8_t>((value >> 56) & 0xFF);
@@ -392,7 +416,7 @@ std::string StreamingResponseWriter::encode_int64_raw(int64_t value) const
     bytes[5] = static_cast<uint8_t>((value >> 16) & 0xFF);
     bytes[6] = static_cast<uint8_t>((value >> 8) & 0xFF);
     bytes[7] = static_cast<uint8_t>(value & 0xFF);
-    return std::string(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
 void StreamingResponseWriter::seal()
@@ -400,107 +424,85 @@ void StreamingResponseWriter::seal()
     response_buffer.seal();
 }
 
-void StreamingResponseWriter::write_path_node(std::ostream& os, ObjectId oid) const
+void StreamingResponseWriter::get_path_node(ObjectId oid, std::vector<ObjectId>& nodes)
 {
-    const auto encoded_oid = encode_object_id(oid);
-    os.write(encoded_oid.c_str(), encoded_oid.size());
+    nodes.emplace_back(oid);
 }
 
-void StreamingResponseWriter::write_path_edge(
-    std::ostream& os,
+void StreamingResponseWriter::get_path_edge(
     ObjectId oid,
     bool reverse,
-    uint_fast32_t* path_length
-) const
+    std::vector<std::pair<ObjectId, bool>>& edges
+)
 {
-    const std::string direction = reverse ? "left" : "right";
-
-    const std::string direction_size = encode_size(direction.size());
-    os.write(direction_size.c_str(), direction_size.size());
-
-    os.write(direction.c_str(), direction.size());
-
-    const auto encoded_oid = encode_object_id(oid);
-    os.write(encoded_oid.c_str(), encoded_oid.size());
-
-    ++(*path_length);
+    edges.emplace_back(oid, reverse);
 }
 
-void StreamingResponseWriter::write_size(uint_fast32_t value)
+void StreamingResponseWriter::write_path_edge(ObjectId oid, bool reverse)
 {
-    uint8_t bytes[4];
-    bytes[0] = static_cast<uint8_t>((value >> 24) & 0xFF);
-    bytes[1] = static_cast<uint8_t>((value >> 16) & 0xFF);
-    bytes[2] = static_cast<uint8_t>((value >> 8) & 0xFF);
-    bytes[3] = static_cast<uint8_t>(value & 0xFF);
-    response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    write_string_raw(reverse ? "left" : "right");
+    write_object_id(oid);
 }
 
-std::string StreamingResponseWriter::encode_dictionary(const Dictionary& dictionary) const
+void StreamingResponseWriter::write_dictionary(const Dictionary& dictionary)
 {
     if (auto literal = dynamic_cast<DictionaryLiteral*>(dictionary.dictionary.get())) {
-        return encode_dictionary_literal(*literal);
+        write_object_id(literal->object_id);
     } else if (auto array = dynamic_cast<DictionaryArray*>(dictionary.dictionary.get())) {
-        return encode_dictionary_array(*array);
+        write_dictionary_array(*array);
     } else if (auto object = dynamic_cast<DictionaryObject*>(dictionary.dictionary.get())) {
-        return encode_dictionary_object(*object);
+        write_dictionary_object(*object);
+    } else {
+        write_null(); // should throw error instead?
     }
-    return encode_null();
 }
 
-std::string StreamingResponseWriter::encode_dictionary_object(const DictionaryObject& dictionary) const
+void StreamingResponseWriter::write_dictionary_object(const DictionaryObject& dictionary)
 {
-    std::string res;
-    res += static_cast<uint8_t>(Protocol::DataType::MAP);
-    res += encode_size(dictionary.keys.size());
+    response_ostream.put(static_cast<char>(Protocol::DataType::MAP));
+    write_size(dictionary.keys.size());
 
-    for (auto&& [key, value] : dictionary.keys) {
-        res += encode_dictionary_key(key);
+    for (const auto& [key, value] : dictionary.keys) {
+        write_dictionary_key(key);
 
         if (auto literal = dynamic_cast<DictionaryLiteral*>(value.get())) {
-            res += encode_dictionary_literal(*literal);
+            write_object_id(literal->object_id);
         } else if (auto array = dynamic_cast<DictionaryArray*>(value.get())) {
-            res += encode_dictionary_array(*array);
+            write_dictionary_array(*array);
         } else if (auto object = dynamic_cast<DictionaryObject*>(value.get())) {
-            res += encode_dictionary_object(*object);
+            write_dictionary_object(*object);
         }
     }
-    return res;
 }
 
-std::string StreamingResponseWriter::encode_dictionary_array(const DictionaryArray& dictionary_array) const
+void StreamingResponseWriter::write_dictionary_array(const DictionaryArray& dictionary_array)
 {
-    std::string res;
-
-    res += static_cast<uint8_t>(Protocol::DataType::LIST);
-    res += encode_size(dictionary_array.values.size());
+    response_ostream.put(static_cast<char>(Protocol::DataType::LIST));
+    write_size(dictionary_array.values.size());
 
     for (auto& elem : dictionary_array.values) {
         if (auto literal = dynamic_cast<DictionaryLiteral*>(elem.get())) {
-            res += encode_dictionary_literal(*literal);
+            write_object_id(literal->object_id);
         } else if (auto array = dynamic_cast<DictionaryArray*>(elem.get())) {
-            res += encode_dictionary_array(*array);
+            write_dictionary_array(*array);
         } else if (auto object = dynamic_cast<DictionaryObject*>(elem.get())) {
-            res += encode_dictionary_object(*object);
+            write_dictionary_object(*object);
         }
     }
-    return res;
 }
 
-std::string StreamingResponseWriter::encode_dictionary_literal(const DictionaryLiteral& dictionary_literal
-) const
+void StreamingResponseWriter::write_edge(uint64_t edge_id)
 {
-    return encode_object_id(dictionary_literal.object_id);
+    response_ostream.put(static_cast<char>(Protocol::DataType::EDGE));
+    write_int64_raw(edge_id);
 }
 
-std::string StreamingResponseWriter::encode_edge(int64_t edge_id) const
+
+void StreamingResponseWriter::write_anon(uint64_t anon_id)
 {
-    std::string res;
-    res += static_cast<char>(Protocol::DataType::EDGE);
-    res += encode_int64_raw(edge_id);
-    return res;
+    response_ostream.put(static_cast<char>(Protocol::DataType::ANON));
+    write_int64_raw(anon_id);
 }
 
-template std::string StreamingResponseWriter::encode_tensor<float>(const tensor::Tensor<float>& tensor) const;
-template std::string StreamingResponseWriter::encode_tensor<double>(const tensor::Tensor<double>& tensor
-) const;
+template void StreamingResponseWriter::write_tensor<float>(const tensor::Tensor<float>& tensor);
+template void StreamingResponseWriter::write_tensor<double>(const tensor::Tensor<double>& tensor);

--- a/src/network/server/session/streaming/response/streaming_response_writer.cc
+++ b/src/network/server/session/streaming/response/streaming_response_writer.cc
@@ -285,8 +285,6 @@ void StreamingResponseWriter::write_path(uint64_t path_id)
 {
     using namespace std::placeholders;
 
-    response_ostream.put(static_cast<char>(Protocol::DataType::PATH));
-
     std::vector<ObjectId> nodes;
     std::vector<std::pair<ObjectId, bool>> edges;
     path_manager.for_each(

--- a/src/network/server/session/streaming/response/streaming_response_writer.h
+++ b/src/network/server/session/streaming/response/streaming_response_writer.h
@@ -22,8 +22,8 @@ namespace MDBServer {
  */
 class StreamingResponseWriter {
 public:
-    // Convert an object id to its string representation
-    virtual std::string encode_object_id(const ObjectId& oid) const = 0;
+    // Write any object id to the response_ostream
+    virtual void write_object_id(const ObjectId& oid) = 0;
 
     virtual uint64_t get_model_id() const = 0;
 
@@ -40,36 +40,38 @@ public:
     void flush();
 
     // Primitive types encoding
-    std::string encode_null() const;
-    std::string encode_bool(bool value) const;
-    std::string encode_uint8(uint8_t value) const;
-    std::string encode_float(float value) const;
-    std::string encode_double(double value) const;
-    std::string encode_uint32(uint32_t value) const;
-    std::string encode_uint64(uint64_t value) const;
-    std::string encode_int64(int64_t value) const;
-    std::string encode_string(const std::string& value, Protocol::DataType data_type) const;
-    std::string encode_path(uint64_t path_id) const;
-    std::string encode_date(DateTime datetime) const;
-    std::string encode_time(DateTime datetime) const;
-    std::string encode_datetime(DateTime datetime) const;
-    std::string encode_dictionary(const Dictionary& dictionary) const;
-    std::string encode_dictionary_object(const DictionaryObject& dictionary) const;
-    std::string encode_dictionary_array(const DictionaryArray& dictionary) const;
-    std::string encode_dictionary_literal(const DictionaryLiteral& dictionary) const;
-    std::string encode_edge(int64_t edge_id) const;
+    void write_null();
+    void write_bool(bool value);
+    void write_uint8(uint8_t value);
+    void write_float(float value);
+    void write_double(double value);
+    void write_uint32(uint32_t value);
+    void write_uint64(uint64_t value);
+    void write_int64(int64_t value);
+    void write_typed_string(const std::string& value, Protocol::DataType datatype);
+    void write_path(uint64_t path_id);
+    void write_date(DateTime datetime);
+    void write_time(DateTime datetime);
+    void write_datetime(DateTime datetime);
+    void write_dictionary(const Dictionary& dictionary);
+    void write_dictionary_object(const DictionaryObject& dictionary);
+    void write_dictionary_array(const DictionaryArray& dictionary);
+    void write_edge(uint64_t edge_id);
+    void write_anon(uint64_t anon_id);
+    template<typename T>
+    void write_tensor(const tensor::Tensor<T>& tensor);
+    void write_list(const std::vector<ObjectId>& list);
 
-    virtual std::string encode_dictionary_key(const ObjectId&) const
-    {
-        return encode_null();
+    virtual void write_dictionary_key(const ObjectId&) {
+        assert(false); // should be overriden if used
     }
 
-    template<typename T>
-    std::string encode_tensor(const tensor::Tensor<T>& tensor) const;
-
     // utilities for composed types
-    std::string encode_int64_raw(int64_t value) const;
-    std::string encode_size(uint32_t value) const;
+    void write_int64_raw(int64_t value);
+    void write_float_raw(float value);
+    void write_double_raw(double value);
+    void write_string_raw(const std::string& value);
+    void write_size(uint32_t value);
 
     // Helpers writing responses
     void write_variables(
@@ -93,61 +95,12 @@ public:
     void write_record(const std::vector<VarId>& projection_vars, const Binding& binding);
     void write_error(const std::string& message);
 
-    void write_object_id(const ObjectId& oid)
-    {
-        const auto encoded_oid = encode_object_id(oid);
-        response_ostream.write(encoded_oid.data(), encoded_oid.size());
-    }
-    void write_null()
-    {
-        const auto enc = encode_null();
-        response_ostream.write(enc.c_str(), enc.size());
-    }
-    void write_uint8(uint8_t value)
-    {
-        const auto enc = encode_uint8(value);
-        response_ostream.write(enc.c_str(), enc.size());
-    }
-    void write_bool(bool value)
-    {
-        const auto enc = encode_bool(value);
-        response_ostream.write(enc.c_str(), enc.size());
-    }
-    void write_uint32(uint32_t value)
-    {
-        const auto enc = encode_uint32(value);
-        response_ostream.write(enc.c_str(), enc.size());
-    }
-    void write_float(float value)
-    {
-        const auto enc = encode_float(value);
-        response_ostream.write(enc.c_str(), enc.size());
-    }
-    void write_double(double value)
-    {
-        const auto enc = encode_double(value);
-        response_ostream.write(enc.c_str(), enc.size());
-    }
-    void write_uint64(uint64_t value)
-    {
-        const auto enc = encode_uint64(value);
-        response_ostream.write(enc.c_str(), enc.size());
-    }
-    void write_int64(int64_t value)
-    {
-        const auto enc = encode_int64(value);
-        response_ostream.write(enc.c_str(), enc.size());
-    }
-    void write_string(const std::string& value, Protocol::DataType data_type = Protocol::DataType::STRING)
-    {
-        const auto enc = encode_string(value, data_type);
-        response_ostream.write(enc.c_str(), enc.size());
-    }
     void write_map_header(uint32_t size)
     {
         response_ostream.put(static_cast<char>(Protocol::DataType::MAP));
         write_size(size);
     }
+
     void write_list_header(uint32_t size)
     {
         response_ostream.put(static_cast<char>(Protocol::DataType::LIST));
@@ -160,13 +113,12 @@ public:
 private:
     StreamingResponseBuffer response_buffer;
 
+    // Path helpers to extract path data
+    void get_path_node(ObjectId oid, std::vector<ObjectId>& nodes);
+    void get_path_edge(ObjectId oid, bool reverse, std::vector<std::pair<ObjectId, bool>>& edges);
+    void write_path_edge(ObjectId oid, bool reverse);
+
+protected:
     std::ostream response_ostream;
-
-    // Path helpers. write_path_edge receives a pointer to a number in order to track the path length.
-    void write_path_node(std::ostream& os, ObjectId oid) const;
-    void write_path_edge(std::ostream& os, ObjectId oid, bool reverse, uint_fast32_t* path_length) const;
-
-    // Write the size prefix of a variable-size object
-    void write_size(uint_fast32_t size);
 };
 } // namespace MDBServer

--- a/src/query/executor/binding_iter/paths/all_shortest_simple/search_state.cc
+++ b/src/query/executor/binding_iter/paths/all_shortest_simple/search_state.cc
@@ -2,10 +2,11 @@
 
 using namespace Paths::AllShortestSimple;
 
-void PathState::print(std::ostream& os,
-                      std::function<void(std::ostream& os, ObjectId)> print_node,
-                      std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                      bool begin_at_left) const
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -19,19 +20,19 @@ void PathState::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/all_shortest_simple/search_state.h
+++ b/src/query/executor/binding_iter/paths/all_shortest_simple/search_state.h
@@ -26,11 +26,11 @@ struct PathState {
         inverse_dir (inverse_dir),
         prev_state  (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
-
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 // Represents a search state to expand

--- a/src/query/executor/binding_iter/paths/all_shortest_trails/search_state.cc
+++ b/src/query/executor/binding_iter/paths/all_shortest_trails/search_state.cc
@@ -2,10 +2,11 @@
 
 using namespace Paths::AllShortestTrails;
 
-void PathState::print(std::ostream& os,
-                      std::function<void(std::ostream& os, ObjectId)> print_node,
-                      std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                      bool begin_at_left) const
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -19,19 +20,19 @@ void PathState::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/all_shortest_trails/search_state.h
+++ b/src/query/executor/binding_iter/paths/all_shortest_trails/search_state.h
@@ -30,10 +30,11 @@ struct PathState {
         inverse_dir (inverse_dir),
         prev_state  (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 // Represents a search state to expand

--- a/src/query/executor/binding_iter/paths/all_shortest_walks/search_state.cc
+++ b/src/query/executor/binding_iter/paths/all_shortest_walks/search_state.cc
@@ -47,10 +47,9 @@ void SearchState::start_enumeration() const
     current_transition->previous->next();
 }
 
-void SearchState::print(
-    std::ostream& os,
-    std::function<void(std::ostream& os, ObjectId)> print_node,
-    std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+void SearchState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
     bool begin_at_left
 ) const
 {
@@ -70,23 +69,22 @@ void SearchState::print(
         }
         nodes.push_back(current_state->node_id);
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
         for (; current_state->current_transition != nullptr;
              current_state = current_state->current_transition->previous)
         {
-            print_node(os, current_state->node_id);
-            print_edge(
-                os,
+            node_func(current_state->node_id);
+            edge_func(
                 current_state->current_transition->type_id,
                 !current_state->current_transition->inverse_direction
             );
         }
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
     }
 }

--- a/src/query/executor/binding_iter/paths/all_shortest_walks/search_state.h
+++ b/src/query/executor/binding_iter/paths/all_shortest_walks/search_state.h
@@ -71,10 +71,9 @@ struct SearchState {
         return automaton_state == other.automaton_state && node_id == other.node_id;
     }
 
-    void print(
-        std::ostream& os,
-        std::function<void(std::ostream& os, ObjectId)> print_node,
-        std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
         bool begin_at_left
     ) const;
 };

--- a/src/query/executor/binding_iter/paths/all_simple/search_state.cc
+++ b/src/query/executor/binding_iter/paths/all_simple/search_state.cc
@@ -2,10 +2,11 @@
 
 using namespace Paths::AllSimple;
 
-void PathState::print(std::ostream& os,
-                      std::function<void(std::ostream& os, ObjectId)> print_node,
-                      std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                      bool begin_at_left) const
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -19,28 +20,28 @@ void PathState::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }
 
-
-void SearchStateDFS::print(std::ostream& os,
-                           std::function<void(std::ostream& os, ObjectId)> print_node,
-                           std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                           bool begin_at_left) const
+void SearchStateDFS::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -54,19 +55,19 @@ void SearchStateDFS::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/all_simple/search_state.h
+++ b/src/query/executor/binding_iter/paths/all_simple/search_state.h
@@ -27,10 +27,11 @@ struct PathState {
         inverse_dir (inverse_dir),
         prev_state  (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 // Represents a search state to expand
@@ -72,10 +73,11 @@ struct SearchStateDFS {
         inverse_dir     (inverse_dir),
         prev_state      (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 inline bool is_simple_path(const PathState* path_state, ObjectId new_node) {

--- a/src/query/executor/binding_iter/paths/all_trails/search_state.cc
+++ b/src/query/executor/binding_iter/paths/all_trails/search_state.cc
@@ -2,10 +2,11 @@
 
 using namespace Paths::AllTrails;
 
-void PathState::print(std::ostream& os,
-                      std::function<void(std::ostream& os, ObjectId)> print_node,
-                      std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                      bool begin_at_left) const
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -19,28 +20,28 @@ void PathState::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }
 
-
-void SearchStateDFS::print(std::ostream& os,
-                           std::function<void(std::ostream& os, ObjectId)> print_node,
-                           std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                           bool begin_at_left) const
+void SearchStateDFS::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -54,19 +55,19 @@ void SearchStateDFS::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/all_trails/search_state.h
+++ b/src/query/executor/binding_iter/paths/all_trails/search_state.h
@@ -30,10 +30,11 @@ struct PathState {
         inverse_dir (inverse_dir),
         prev_state  (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 // Represents a search state to expand
@@ -74,10 +75,11 @@ struct SearchStateDFS {
         inverse_dir     (inverse_dir),
         prev_state      (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 inline bool is_trail(const PathState* path_state, ObjectId new_edge) {

--- a/src/query/executor/binding_iter/paths/any_simple/search_state.cc
+++ b/src/query/executor/binding_iter/paths/any_simple/search_state.cc
@@ -2,10 +2,11 @@
 
 using namespace Paths::AnySimple;
 
-void PathState::print(std::ostream& os,
-                      std::function<void(std::ostream& os, ObjectId)> print_node,
-                      std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                      bool begin_at_left) const
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -19,28 +20,28 @@ void PathState::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }
 
-
-void SearchStateDFS::print(std::ostream& os,
-                           std::function<void(std::ostream& os, ObjectId)> print_node,
-                           std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                           bool begin_at_left) const
+void SearchStateDFS::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -54,19 +55,19 @@ void SearchStateDFS::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func( nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func( current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/any_simple/search_state.h
+++ b/src/query/executor/binding_iter/paths/any_simple/search_state.h
@@ -27,10 +27,11 @@ struct PathState {
         inverse_dir (inverse_dir),
         prev_state  (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 // Represents a search state to expand
@@ -69,10 +70,11 @@ struct SearchStateDFS {
         inverse_dir     (inverse_dir),
         prev_state      (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 inline bool is_simple_path(const PathState* path_state, ObjectId new_node) {

--- a/src/query/executor/binding_iter/paths/any_trails/search_state.cc
+++ b/src/query/executor/binding_iter/paths/any_trails/search_state.cc
@@ -2,11 +2,11 @@
 
 using namespace Paths::AnyTrails;
 
-
-void PathState::print(std::ostream& os,
-                      std::function<void(std::ostream& os, ObjectId)> print_node,
-                      std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                      bool begin_at_left) const
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -20,28 +20,28 @@ void PathState::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }
 
-
-void SearchStateDFS::print(std::ostream& os,
-                           std::function<void(std::ostream& os, ObjectId)> print_node,
-                           std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                           bool begin_at_left) const
+void SearchStateDFS::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -55,19 +55,19 @@ void SearchStateDFS::print(std::ostream& os,
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/any_trails/search_state.h
+++ b/src/query/executor/binding_iter/paths/any_trails/search_state.h
@@ -30,10 +30,11 @@ struct PathState {
         inverse_dir (inverse_dir),
         prev_state  (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 // Represents a search state to expand
@@ -75,10 +76,11 @@ struct SearchStateDFS {
         inverse_dir     (inverse_dir),
         prev_state      (prev_state) { }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 inline bool is_trail(const PathState* path_state, ObjectId new_edge) {

--- a/src/query/executor/binding_iter/paths/any_walks/search_state.cc
+++ b/src/query/executor/binding_iter/paths/any_walks/search_state.cc
@@ -2,11 +2,11 @@
 
 using namespace Paths::Any;
 
-void SearchState::print(
-    std::ostream& os,
-    std::function<void(std::ostream& os, ObjectId)> print_node,
-    std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-    bool begin_at_left) const
+void SearchState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -20,29 +20,28 @@ void SearchState::print(
             inverse_directions.push_back(current_state->inverse_direction);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func( current_state->node_id);
 
         while (current_state->previous != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_direction);
+            edge_func(current_state->type_id, !current_state->inverse_direction);
             current_state = current_state->previous;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }
 
-
-void DirectionalSearchState::print(
-    std::ostream& os,
-    std::function<void(std::ostream& os, ObjectId)> print_node,
-    std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-    bool begin_at_left) const
+void DirectionalSearchState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -56,19 +55,19 @@ void DirectionalSearchState::print(
             inverse_directions.push_back(current_state->inverse_direction);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->previous != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_direction);
+            edge_func(current_state->type_id, !current_state->inverse_direction);
             current_state = current_state->previous;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/any_walks/search_state.h
+++ b/src/query/executor/binding_iter/paths/any_walks/search_state.h
@@ -88,10 +88,9 @@ struct SearchState {
         return SearchState(automaton_state, node_id, previous, inverse_direction, type_id);
     }
 
-    void print(
-        std::ostream& os,
-        std::function<void(std::ostream& os, ObjectId)> print_node,
-        std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
         bool begin_at_left
     ) const;
 };
@@ -151,10 +150,9 @@ struct DirectionalSearchState {
         );
     }
 
-    void print(
-        std::ostream& os,
-        std::function<void(std::ostream& os, ObjectId)> print_node,
-        std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
         bool begin_at_left
     ) const;
 };

--- a/src/query/executor/binding_iter/paths/experimental/search_state_dijkstra.cc
+++ b/src/query/executor/binding_iter/paths/experimental/search_state_dijkstra.cc
@@ -5,10 +5,11 @@
 using namespace Paths::Any;
 using namespace std;
 
-void SearchStateDijkstra::print(ostream& os,
-                                std::function<void(std::ostream& os, ObjectId)> print_node,
-                                std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-                                bool begin_at_left) const
+void SearchStateDijkstra::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
+    bool begin_at_left
+) const
 {
     if (begin_at_left) {
         // the path need to be reconstructed in the reverse direction (last seen goes first)
@@ -22,19 +23,19 @@ void SearchStateDijkstra::print(ostream& os,
             inverse_directions.push_back(current_state->inverse_direction);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->previous != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_direction);
+            edge_func(current_state->type_id, !current_state->inverse_direction);
             current_state = current_state->previous;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/experimental/search_state_dijkstra.h
+++ b/src/query/executor/binding_iter/paths/experimental/search_state_dijkstra.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <ostream>
 
 #include "graph_models/object_id.h"
 
@@ -60,10 +59,11 @@ struct SearchStateDijkstra {
         return SearchStateDijkstra(automaton_state, node_id, previous, inverse_direction, type_id, cost, inverted_path);
     }
 
-    void print(std::ostream& os,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
-               bool begin_at_left) const;
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
+        bool begin_at_left
+    ) const;
 };
 
 // Represents a priority queue element for Dijkstra's algorithm

--- a/src/query/executor/binding_iter/paths/shortest_k/simple/search_state.cc
+++ b/src/query/executor/binding_iter/paths/shortest_k/simple/search_state.cc
@@ -4,10 +4,9 @@
 
 using namespace Paths::ShortestKSimple;
 
-void PathState::print(
-    std::ostream& os,
-    std::function<void(std::ostream& os, ObjectId)> print_node,
-    std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
     bool begin_at_left
 ) const
 {
@@ -23,19 +22,19 @@ void PathState::print(
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/shortest_k/simple/search_state.h
+++ b/src/query/executor/binding_iter/paths/shortest_k/simple/search_state.h
@@ -23,10 +23,9 @@ struct PathState {
         prev_state(prev_state)
     { }
 
-    void print(
-        std::ostream& os,
-        std::function<void(std::ostream& os, ObjectId)> print_node,
-        std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
         bool begin_at_left
     ) const;
 };

--- a/src/query/executor/binding_iter/paths/shortest_k/trails/search_state.cc
+++ b/src/query/executor/binding_iter/paths/shortest_k/trails/search_state.cc
@@ -4,10 +4,9 @@
 
 using namespace Paths::ShortestKTrails;
 
-void PathState::print(
-    std::ostream& os,
-    std::function<void(std::ostream& os, ObjectId)> print_node,
-    std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
     bool begin_at_left
 ) const
 {
@@ -23,19 +22,19 @@ void PathState::print(
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/shortest_k/trails/search_state.h
+++ b/src/query/executor/binding_iter/paths/shortest_k/trails/search_state.h
@@ -31,10 +31,9 @@ struct PathState {
         prev_state(prev_state)
     { }
 
-    void print(
-        std::ostream& os,
-        std::function<void(std::ostream& os, ObjectId)> print_node,
-        std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
         bool begin_at_left
     ) const;
 };

--- a/src/query/executor/binding_iter/paths/shortest_k/walks/search_state.cc
+++ b/src/query/executor/binding_iter/paths/shortest_k/walks/search_state.cc
@@ -57,10 +57,9 @@ void PathIter::start_enumeration()
     current = nullptr;
 }
 
-void SearchState::print(
-    std::ostream& os,
-    std::function<void(std::ostream& os, ObjectId)> print_node,
-    std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+void SearchState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
     bool begin_at_left
 ) const
 {
@@ -80,23 +79,22 @@ void SearchState::print(
         }
         nodes.push_back(current_state->node_id);
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
         for (; current_state->path_iter.current->previous != nullptr;
             current_state = current_state->path_iter.current->previous)
         {
-            print_node(os, current_state->node_id);
-            print_edge(
-                os,
+            node_func(current_state->node_id);
+            edge_func(
                 current_state->path_iter.current->type_id,
                 !current_state->path_iter.current->inverse_direction
             );
         }
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
     }
 }

--- a/src/query/executor/binding_iter/paths/shortest_k/walks/search_state.h
+++ b/src/query/executor/binding_iter/paths/shortest_k/walks/search_state.h
@@ -86,10 +86,9 @@ struct SearchState {
             && distance == other.distance;
     }
 
-    void print(
-        std::ostream& os,
-        std::function<void(std::ostream& os, ObjectId)> print_node,
-        std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
         bool begin_at_left
     ) const;
 };

--- a/src/query/executor/binding_iter/paths/shortest_k_groups/simple/search_state.cc
+++ b/src/query/executor/binding_iter/paths/shortest_k_groups/simple/search_state.cc
@@ -2,10 +2,9 @@
 
 using namespace Paths::ShortestKGroupsSimple;
 
-void PathState::print(
-    std::ostream& os,
-    std::function<void(std::ostream& os, ObjectId)> print_node,
-    std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
     bool begin_at_left
 ) const
 {
@@ -21,19 +20,19 @@ void PathState::print(
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/shortest_k_groups/simple/search_state.h
+++ b/src/query/executor/binding_iter/paths/shortest_k_groups/simple/search_state.h
@@ -24,10 +24,9 @@ struct PathState {
         prev_state(prev_state)
     { }
 
-    void print(
-        std::ostream& os,
-        std::function<void(std::ostream& os, ObjectId)> print_node,
-        std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
         bool begin_at_left
     ) const;
 };

--- a/src/query/executor/binding_iter/paths/shortest_k_groups/trails/search_state.cc
+++ b/src/query/executor/binding_iter/paths/shortest_k_groups/trails/search_state.cc
@@ -2,10 +2,9 @@
 
 using namespace Paths::ShortestKGroupsTrails;
 
-void PathState::print(
-    std::ostream& os,
-    std::function<void(std::ostream& os, ObjectId)> print_node,
-    std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+void PathState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
     bool begin_at_left
 ) const
 {
@@ -21,19 +20,19 @@ void PathState::print(
             inverse_directions.push_back(current_state->inverse_dir);
         }
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
 
         while (current_state->prev_state != nullptr) {
-            print_edge(os, current_state->type_id, !current_state->inverse_dir);
+            edge_func(current_state->type_id, !current_state->inverse_dir);
             current_state = current_state->prev_state;
-            print_node(os, current_state->node_id);
+            node_func(current_state->node_id);
         }
     }
 }

--- a/src/query/executor/binding_iter/paths/shortest_k_groups/trails/search_state.h
+++ b/src/query/executor/binding_iter/paths/shortest_k_groups/trails/search_state.h
@@ -26,10 +26,9 @@ struct PathState {
         prev_state(prev_state)
     { }
 
-    void print(
-        std::ostream& os,
-        std::function<void(std::ostream& os, ObjectId)> print_node,
-        std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
         bool begin_at_left
     ) const;
 };

--- a/src/query/executor/binding_iter/paths/shortest_k_groups/walks/search_state.cc
+++ b/src/query/executor/binding_iter/paths/shortest_k_groups/walks/search_state.cc
@@ -57,10 +57,9 @@ void PathIter::start_enumeration()
     current = nullptr;
 }
 
-void SearchState::print(
-    std::ostream& os,
-    std::function<void(std::ostream& os, ObjectId)> print_node,
-    std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+void SearchState::for_each(
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func,
     bool begin_at_left
 ) const
 {
@@ -80,23 +79,22 @@ void SearchState::print(
         }
         nodes.push_back(current_state->node_id);
 
-        print_node(os, nodes[nodes.size() - 1]);
+        node_func(nodes[nodes.size() - 1]);
         for (int_fast32_t i = nodes.size() - 2; i >= 0; i--) { // don't use unsigned i, will overflow
-            print_edge(os, edges[i], inverse_directions[i]);
-            print_node(os, nodes[i]);
+            edge_func(edges[i], inverse_directions[i]);
+            node_func(nodes[i]);
         }
     } else {
         auto current_state = this;
         for (; current_state->path_iter.current->previous != nullptr;
             current_state = current_state->path_iter.current->previous)
         {
-            print_node(os, current_state->node_id);
-            print_edge(
-                os,
+            node_func(current_state->node_id);
+            edge_func(
                 current_state->path_iter.current->type_id,
                 !current_state->path_iter.current->inverse_direction
             );
         }
-        print_node(os, current_state->node_id);
+        node_func(current_state->node_id);
     }
 }

--- a/src/query/executor/binding_iter/paths/shortest_k_groups/walks/search_state.h
+++ b/src/query/executor/binding_iter/paths/shortest_k_groups/walks/search_state.h
@@ -82,10 +82,9 @@ struct SearchState {
             && distance == other.distance;
     }
 
-    void print(
-        std::ostream& os,
-        std::function<void(std::ostream& os, ObjectId)> print_node,
-        std::function<void(std::ostream& os, ObjectId, bool)> print_edge,
+    void for_each(
+        std::function<void(ObjectId)> node_func,
+        std::function<void(ObjectId, bool)> edge_func,
         bool begin_at_left
     ) const;
 };

--- a/src/query/executor/query_executor/mql/describe_streaming_executor.cc
+++ b/src/query/executor/query_executor/mql/describe_streaming_executor.cc
@@ -68,10 +68,10 @@ uint64_t DescribeStreamingExecutor::execute(MDBServer::StreamingResponseWriter& 
     }
 
     response_writer.write_map_header(2UL);
-    response_writer.write_string("type");
+    response_writer.write_typed_string("type", MDBServer::Protocol::DataType::STRING);
     response_writer.write_uint8(static_cast<uint8_t>(MDBServer::Protocol::ResponseType::RECORD));
 
-    response_writer.write_string("payload");
+    response_writer.write_typed_string("payload", MDBServer::Protocol::DataType::STRING);
     response_writer.write_list_header(projection_vars.size());
 
     // Object
@@ -122,13 +122,13 @@ uint64_t DescribeStreamingExecutor::execute(MDBServer::StreamingResponseWriter& 
         response_writer.write_list_header(from_to_type_edge.size());
         for (const auto& [from, to, type, edge] : from_to_type_edge) {
             response_writer.write_map_header(4);
-            response_writer.write_string("from");
+            response_writer.write_typed_string("from", MDBServer::Protocol::DataType::STRING);
             response_writer.write_object_id(from);
-            response_writer.write_string("to");
+            response_writer.write_typed_string("to", MDBServer::Protocol::DataType::STRING);
             response_writer.write_object_id(to);
-            response_writer.write_string("type");
+            response_writer.write_typed_string("type", MDBServer::Protocol::DataType::STRING);
             response_writer.write_object_id(type);
-            response_writer.write_string("edge");
+            response_writer.write_typed_string("edge", MDBServer::Protocol::DataType::STRING);
             response_writer.write_object_id(edge);
         }
     }
@@ -147,13 +147,13 @@ uint64_t DescribeStreamingExecutor::execute(MDBServer::StreamingResponseWriter& 
         response_writer.write_list_header(to_type_from_edge.size());
         for (const auto& [to, type, from, edge] : to_type_from_edge) {
             response_writer.write_map_header(4);
-            response_writer.write_string("from");
+            response_writer.write_typed_string("from", MDBServer::Protocol::DataType::STRING);
             response_writer.write_object_id(from);
-            response_writer.write_string("to");
+            response_writer.write_typed_string("to", MDBServer::Protocol::DataType::STRING);
             response_writer.write_object_id(to);
-            response_writer.write_string("type");
+            response_writer.write_typed_string("type", MDBServer::Protocol::DataType::STRING);
             response_writer.write_object_id(type);
-            response_writer.write_string("edge");
+            response_writer.write_typed_string("edge", MDBServer::Protocol::DataType::STRING);
             response_writer.write_object_id(edge);
         }
     }

--- a/src/query/executor/query_executor/mql/edge_describe_streaming_executor.cc
+++ b/src/query/executor/query_executor/mql/edge_describe_streaming_executor.cc
@@ -55,10 +55,10 @@ uint64_t EdgeDescribeStreamingExecutor::execute(MDBServer::StreamingResponseWrit
     }
 
     response_writer.write_map_header(2UL);
-    response_writer.write_string("type", MDBServer::Protocol::DataType::STRING);
+    response_writer.write_typed_string("type", MDBServer::Protocol::DataType::STRING);
     response_writer.write_uint8(static_cast<uint8_t>(MDBServer::Protocol::ResponseType::RECORD));
 
-    response_writer.write_string("payload", MDBServer::Protocol::DataType::STRING);
+    response_writer.write_typed_string("payload", MDBServer::Protocol::DataType::STRING);
     response_writer.write_list_header(projection_vars.size());
 
     response_writer.write_object_id(object_id); // edge_id

--- a/src/query/executor/query_executor/mql/return_executor.cc
+++ b/src/query/executor/query_executor/mql/return_executor.cc
@@ -140,13 +140,11 @@ void ReturnExecutor<ret>::print(std::ostream& os, std::ostream& escaped_os, Obje
     case ObjectId::MASK_PATH: {
         using namespace std::placeholders;
         os << '[';
-        // TODO:
-        // path_manager.print(
-        //     os,
-        //     unmasked_id,
-        //     std::bind(&ReturnExecutor<ret>::print_path_node, _1, _2),
-        //     std::bind(&ReturnExecutor<ret>::print_path_edge, _1, _2, _3)
-        // );
+        path_manager.for_each(
+            unmasked_id,
+            [&](ObjectId oid) { print_path_node(os, oid); },
+            [&](ObjectId oid, bool reverse) { print_path_edge(os, oid, reverse); }
+        );
         os << ']';
         break;
     }

--- a/src/query/executor/query_executor/mql/return_executor.cc
+++ b/src/query/executor/query_executor/mql/return_executor.cc
@@ -140,12 +140,13 @@ void ReturnExecutor<ret>::print(std::ostream& os, std::ostream& escaped_os, Obje
     case ObjectId::MASK_PATH: {
         using namespace std::placeholders;
         os << '[';
-        path_manager.print(
-            os,
-            unmasked_id,
-            std::bind(&ReturnExecutor<ret>::print_path_node, _1, _2),
-            std::bind(&ReturnExecutor<ret>::print_path_edge, _1, _2, _3)
-        );
+        // TODO:
+        // path_manager.print(
+        //     os,
+        //     unmasked_id,
+        //     std::bind(&ReturnExecutor<ret>::print_path_node, _1, _2),
+        //     std::bind(&ReturnExecutor<ret>::print_path_edge, _1, _2, _3)
+        // );
         os << ']';
         break;
     }

--- a/src/query/executor/query_executor/mql/show_streaming_executor.cc
+++ b/src/query/executor/query_executor/mql/show_streaming_executor.cc
@@ -39,14 +39,14 @@ uint64_t ShowStreamingExecutor<type>::execute(MDBServer::StreamingResponseWriter
                                 const HIMeta& metadata,
                                 const HNSW::HNSWIndex::HNSWIndexParams& params) {
             response_writer.write_map_header(2UL);
-            response_writer.write_string("type", MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string("type", MDBServer::Protocol::DataType::STRING);
             response_writer.write_uint8(static_cast<uint8_t>(MDBServer::Protocol::ResponseType::RECORD));
 
-            response_writer.write_string("payload", MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string("payload", MDBServer::Protocol::DataType::STRING);
             response_writer.write_list_header(projection_vars.size());
-            response_writer.write_string(name, MDBServer::Protocol::DataType::STRING);
-            response_writer.write_string(metadata.predicate, MDBServer::Protocol::DataType::STRING);
-            response_writer.write_string(
+            response_writer.write_typed_string(name, MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string(metadata.predicate, MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string(
                 to_string(metadata.metric_type),
                 MDBServer::Protocol::DataType::STRING
             );
@@ -72,18 +72,18 @@ uint64_t ShowStreamingExecutor<type>::execute(MDBServer::StreamingResponseWriter
 
         auto write_record = [&](const std::string& name, const TIMeta& metadata) {
             response_writer.write_map_header(2UL);
-            response_writer.write_string("type", MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string("type", MDBServer::Protocol::DataType::STRING);
             response_writer.write_uint8(static_cast<uint8_t>(MDBServer::Protocol::ResponseType::RECORD));
 
-            response_writer.write_string("payload", MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string("payload", MDBServer::Protocol::DataType::STRING);
             response_writer.write_list_header(projection_vars.size());
-            response_writer.write_string(name, MDBServer::Protocol::DataType::STRING);
-            response_writer.write_string(metadata.predicate, MDBServer::Protocol::DataType::STRING);
-            response_writer.write_string(
+            response_writer.write_typed_string(name, MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string(metadata.predicate, MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string(
                 to_string(metadata.normalization_type),
                 MDBServer::Protocol::DataType::STRING
             );
-            response_writer.write_string(
+            response_writer.write_typed_string(
                 to_string(metadata.tokenization_type),
                 MDBServer::Protocol::DataType::STRING
             );

--- a/src/query/executor/query_executor/sparql/ask_streaming_executor.cc
+++ b/src/query/executor/query_executor/sparql/ask_streaming_executor.cc
@@ -16,10 +16,10 @@ uint64_t AskStreamingExecutor::execute(MDBServer::StreamingResponseWriter& respo
     const bool has_result = iter->next();
 
     response_writer.write_map_header(2UL);
-    response_writer.write_string("type", MDBServer::Protocol::DataType::STRING);
+    response_writer.write_typed_string("type", MDBServer::Protocol::DataType::STRING);
     response_writer.write_uint8(static_cast<uint8_t>(MDBServer::Protocol::ResponseType::RECORD));
 
-    response_writer.write_string("payload", MDBServer::Protocol::DataType::STRING);
+    response_writer.write_typed_string("payload", MDBServer::Protocol::DataType::STRING);
     response_writer.write_list_header(1);
     response_writer.write_bool(has_result);
 

--- a/src/query/executor/query_executor/sparql/csv_select_executor.cc
+++ b/src/query/executor/query_executor/sparql/csv_select_executor.cc
@@ -129,11 +129,12 @@ void CSVSelectExecutor::print(std::ostream& os, std::ostream& escaped_os, Object
     case RDF_OID::Type::PATH: {
         using namespace std::placeholders;
         os << '[';
-        path_manager.print(os,
-                           Conversions::get_path_id(oid),
-                           std::bind(&CSVSelectExecutor::print_path_node, _1, _2),
-                           std::bind(&CSVSelectExecutor::print_path_edge, _1, _2, _3));
-        os << ']';
+        // TODO:
+        // path_manager.print(os,
+        //                    Conversions::get_path_id(oid),
+        //                    std::bind(&CSVSelectExecutor::print_path_node, _1, _2),
+        //                    std::bind(&CSVSelectExecutor::print_path_edge, _1, _2, _3));
+        // os << ']';
         break;
     }
     case RDF_OID::Type::IRI_INLINE:

--- a/src/query/executor/query_executor/sparql/csv_select_executor.cc
+++ b/src/query/executor/query_executor/sparql/csv_select_executor.cc
@@ -129,12 +129,12 @@ void CSVSelectExecutor::print(std::ostream& os, std::ostream& escaped_os, Object
     case RDF_OID::Type::PATH: {
         using namespace std::placeholders;
         os << '[';
-        // TODO:
-        // path_manager.print(os,
-        //                    Conversions::get_path_id(oid),
-        //                    std::bind(&CSVSelectExecutor::print_path_node, _1, _2),
-        //                    std::bind(&CSVSelectExecutor::print_path_edge, _1, _2, _3));
-        // os << ']';
+        path_manager.for_each(
+            Conversions::get_path_id(oid),
+            [&](ObjectId oid) { print_path_node(os, oid); },
+            [&](ObjectId oid, bool reverse) { print_path_edge(os, oid, reverse); }
+        );
+        os << ']';
         break;
     }
     case RDF_OID::Type::IRI_INLINE:

--- a/src/query/executor/query_executor/sparql/json_select_executor.cc
+++ b/src/query/executor/query_executor/sparql/json_select_executor.cc
@@ -70,8 +70,8 @@ uint64_t JsonSelectExecutor::execute(std::ostream& os) {
     return result_count;
 }
 
-
-void JsonSelectExecutor::print_path_node(std::ostream& os, ObjectId node_id) {
+void JsonSelectExecutor::print_path_node(ObjectId node_id, std::ostream& os)
+{
     JsonOstreamEscape ostream_escape(os);
     std::ostream escaped_os(&ostream_escape);
 
@@ -80,13 +80,12 @@ void JsonSelectExecutor::print_path_node(std::ostream& os, ObjectId node_id) {
     os << "}";
 }
 
-
-void JsonSelectExecutor::print_path_edge(std::ostream& os, ObjectId edge_id, bool inverse) {
+void JsonSelectExecutor::print_path_edge(ObjectId edge_id, bool inverse, std::ostream& os)
+{
     os << ",{\"edge\":";
     print(os, os, edge_id); // No need to escape os, as only IRIs are possible edges
     os << ",\"inverse\":" << (inverse ? "true" : "false") << "},";
 }
-
 
 void JsonSelectExecutor::print(std::ostream& os, std::ostream& escaped_os, ObjectId oid) {
     switch (RDF_OID::get_type(oid)) {
@@ -158,10 +157,11 @@ void JsonSelectExecutor::print(std::ostream& os, std::ostream& escaped_os, Objec
     case RDF_OID::Type::PATH: {
         using namespace std::placeholders;
         os << "{\"type\":\"path\",\"value\":[";
-        path_manager.print(os,
-                           Conversions::get_path_id(oid),
-                           std::bind(print_path_node, _1, _2),
-                           std::bind(print_path_edge, _1, _2, _3));
+        path_manager.for_each(
+            Conversions::get_path_id(oid),
+            [&](ObjectId oid) { print_path_node(oid, os); },
+            [&](ObjectId oid, bool reverse) { print_path_edge(oid, reverse, os); }
+        );
         os << "]}";
         break;
     }

--- a/src/query/executor/query_executor/sparql/json_select_executor.h
+++ b/src/query/executor/query_executor/sparql/json_select_executor.h
@@ -30,8 +30,8 @@ private:
 
     static void print(std::ostream& os, std::ostream& escaped_os, ObjectId);
 
-    static void print_path_node(std::ostream& os, ObjectId node_id);
+    static void print_path_node(ObjectId node_id, std::ostream& os);
 
-    static void print_path_edge(std::ostream& os, ObjectId edge_id, bool inverse);
+    static void print_path_edge(ObjectId edge_id, bool inverse, std::ostream& os);
 };
 } // namespace SPARQL

--- a/src/query/executor/query_executor/sparql/show_streaming_executor.cc
+++ b/src/query/executor/query_executor/sparql/show_streaming_executor.cc
@@ -39,14 +39,14 @@ uint64_t ShowStreamingExecutor<type>::execute(MDBServer::StreamingResponseWriter
                                 const HIMeta& metadata,
                                 const HNSW::HNSWIndex::HNSWIndexParams& params) {
             response_writer.write_map_header(2UL);
-            response_writer.write_string("type", MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string("type", MDBServer::Protocol::DataType::STRING);
             response_writer.write_uint8(static_cast<uint8_t>(MDBServer::Protocol::ResponseType::RECORD));
 
-            response_writer.write_string("payload", MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string("payload", MDBServer::Protocol::DataType::STRING);
             response_writer.write_list_header(projection_vars.size());
-            response_writer.write_string(name, MDBServer::Protocol::DataType::STRING);
-            response_writer.write_string(metadata.predicate, MDBServer::Protocol::DataType::IRI);
-            response_writer.write_string(
+            response_writer.write_typed_string(name, MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string(metadata.predicate, MDBServer::Protocol::DataType::IRI);
+            response_writer.write_typed_string(
                 to_string(metadata.metric_type),
                 MDBServer::Protocol::DataType::STRING
             );
@@ -72,18 +72,18 @@ uint64_t ShowStreamingExecutor<type>::execute(MDBServer::StreamingResponseWriter
 
         auto write_record = [&](const std::string& name, const TIMeta& metadata) {
             response_writer.write_map_header(2UL);
-            response_writer.write_string("type", MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string("type", MDBServer::Protocol::DataType::STRING);
             response_writer.write_uint8(static_cast<uint8_t>(MDBServer::Protocol::ResponseType::RECORD));
 
-            response_writer.write_string("payload", MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string("payload", MDBServer::Protocol::DataType::STRING);
             response_writer.write_list_header(projection_vars.size());
-            response_writer.write_string(name, MDBServer::Protocol::DataType::STRING);
-            response_writer.write_string(metadata.predicate, MDBServer::Protocol::DataType::IRI);
-            response_writer.write_string(
+            response_writer.write_typed_string(name, MDBServer::Protocol::DataType::STRING);
+            response_writer.write_typed_string(metadata.predicate, MDBServer::Protocol::DataType::IRI);
+            response_writer.write_typed_string(
                 to_string(metadata.normalization_type),
                 MDBServer::Protocol::DataType::STRING
             );
-            response_writer.write_string(
+            response_writer.write_typed_string(
                 to_string(metadata.tokenization_type),
                 MDBServer::Protocol::DataType::STRING
             );

--- a/src/query/executor/query_executor/sparql/tsv_select_executor.cc
+++ b/src/query/executor/query_executor/sparql/tsv_select_executor.cc
@@ -57,16 +57,16 @@ uint64_t TSVSelectExecutor::execute(std::ostream& os) {
     return result_count;
 }
 
-
-void TSVSelectExecutor::print_path_node(std::ostream& os, ObjectId node_id) {
+void TSVSelectExecutor::print_path_node(ObjectId node_id, std::ostream& os)
+{
     TSVOstreamEscape xml_ostream_escape(os);
     std::ostream escaped_os(&xml_ostream_escape);
 
     print(os, escaped_os, node_id);
 }
 
-
-void TSVSelectExecutor::print_path_edge(std::ostream& os, ObjectId edge_id, bool inverse) {
+void TSVSelectExecutor::print_path_edge(ObjectId edge_id, bool inverse, std::ostream& os)
+{
     os << ' ';
     if (inverse) {
         os << '^';
@@ -74,7 +74,6 @@ void TSVSelectExecutor::print_path_edge(std::ostream& os, ObjectId edge_id, bool
     print(os, os, edge_id); // No need to escape os, as only IRIs are possible edges
     os << ' ';
 }
-
 
 void TSVSelectExecutor::print(std::ostream& os, std::ostream& escaped_os, ObjectId oid) {
     switch (RDF_OID::get_type(oid)) {
@@ -137,10 +136,11 @@ void TSVSelectExecutor::print(std::ostream& os, std::ostream& escaped_os, Object
     case RDF_OID::Type::PATH: {
         using namespace std::placeholders;
         os << '[';
-        path_manager.print(os,
-                           Conversions::get_path_id(oid),
-                           std::bind(&TSVSelectExecutor::print_path_node, _1, _2),
-                           std::bind(&TSVSelectExecutor::print_path_edge, _1, _2, _3));
+        path_manager.for_each(
+            Conversions::get_path_id(oid),
+            [&](ObjectId oid) { print_path_node(oid, os); },
+            [&](ObjectId oid, bool reverse) { print_path_edge(oid, reverse, os); }
+        );
         os << ']';
         break;
     }

--- a/src/query/executor/query_executor/sparql/tsv_select_executor.h
+++ b/src/query/executor/query_executor/sparql/tsv_select_executor.h
@@ -30,8 +30,8 @@ private:
 
     static void print(std::ostream& os, std::ostream& escaped_os, ObjectId);
 
-    static void print_path_node(std::ostream& os, ObjectId node_id);
+    static void print_path_node(ObjectId node_id, std::ostream& os);
 
-    static void print_path_edge(std::ostream& os, ObjectId edge_id, bool inverse);
+    static void print_path_edge(ObjectId edge_id, bool inverse, std::ostream& os);
 };
 } // namespace SPARQL

--- a/src/query/executor/query_executor/sparql/xml_select_executor.cc
+++ b/src/query/executor/query_executor/sparql/xml_select_executor.cc
@@ -65,8 +65,8 @@ uint64_t XMLSelectExecutor::execute(std::ostream& os) {
     return result_count;
 }
 
-
-void XMLSelectExecutor::print_path_node(std::ostream& os, ObjectId node_id) {
+void XMLSelectExecutor::print_path_node(ObjectId node_id, std::ostream& os)
+{
     XMLOstreamEscape xml_ostream_escape(os);
     std::ostream escaped_os(&xml_ostream_escape);
 
@@ -75,13 +75,12 @@ void XMLSelectExecutor::print_path_node(std::ostream& os, ObjectId node_id) {
     os << "</node>";
 }
 
-
-void XMLSelectExecutor::print_path_edge(std::ostream& os, ObjectId edge_id, bool inverse) {
+void XMLSelectExecutor::print_path_edge(ObjectId edge_id, bool inverse, std::ostream& os)
+{
     os << "<edge inverse=" << (inverse ? "true" : "false") << ">";
     print(os, os, edge_id); // No need to escape os, as only IRIs are possible edges
     os << "</edge>";
 }
-
 
 void XMLSelectExecutor::print(std::ostream& os, std::ostream& escaped_os, ObjectId oid) {
     switch (RDF_OID::get_type(oid)) {
@@ -153,10 +152,11 @@ void XMLSelectExecutor::print(std::ostream& os, std::ostream& escaped_os, Object
     case RDF_OID::Type::PATH: {
         using namespace std::placeholders;
         os << "<path>";
-        path_manager.print(os,
-                           Conversions::get_path_id(oid),
-                           std::bind(&XMLSelectExecutor::print_path_node, _1, _2),
-                           std::bind(&XMLSelectExecutor::print_path_edge, _1, _2, _3));
+        path_manager.for_each(
+            Conversions::get_path_id(oid),
+            [&](ObjectId oid) { print_path_node(oid, os); },
+            [&](ObjectId oid, bool reverse) { print_path_edge(oid, reverse, os); }
+        );
         os << "</path>";
         break;
     }

--- a/src/query/executor/query_executor/sparql/xml_select_executor.h
+++ b/src/query/executor/query_executor/sparql/xml_select_executor.h
@@ -30,8 +30,8 @@ private:
 
     static void print(std::ostream& os, std::ostream& escaped_os, ObjectId);
 
-    static void print_path_node(std::ostream& os, ObjectId node_id);
+    static void print_path_node(ObjectId node_id, std::ostream& os);
 
-    static void print_path_edge(std::ostream& os, ObjectId edge_id, bool inverse);
+    static void print_path_edge(ObjectId edge_id, bool inverse, std::ostream& os);
 };
 } // namespace SPARQL

--- a/src/system/path_manager.cc
+++ b/src/system/path_manager.cc
@@ -182,11 +182,10 @@ ObjectId PathManager::set_path(const Paths::ShortestKGroupsWalks::SearchState* v
     return ObjectId(ObjectId::MASK_PATH | SHORTEST_K_GROUPS_WALKS_MASK | path_var.id);
 }
 
-void PathManager::print(
-    std::ostream& os,
+void PathManager::for_each(
     uint64_t path_id,
-    std::function<void(std::ostream&, ObjectId)> print_node,
-    std::function<void(std::ostream&, ObjectId, bool)> print_edge
+    std::function<void(ObjectId)> node_func,
+    std::function<void(ObjectId, bool)> edge_func
 ) const
 {
     auto index = get_thread_index();
@@ -201,113 +200,113 @@ void PathManager::print(
     switch (path_type) {
     case ANY_SHORTEST_WALKS_MASK: {
         auto state = reinterpret_cast<const Any::SearchState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ANY_SHORTEST_WALKS_DIR_MASK: {
         auto state = reinterpret_cast<const Any::DirectionalSearchState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ALL_SHORTEST_WALKS_MASK: {
         auto state = reinterpret_cast<const AllShortest::SearchState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case DIJKSTRA_MASK: {
         auto state = reinterpret_cast<const Paths::Any::SearchStateDijkstra*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ANY_SIMPLE_MASK: {
         auto state = reinterpret_cast<const Paths::AnySimple::PathState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ANY_SIMPLE_DFS_MASK: {
         auto state = reinterpret_cast<const Paths::AnySimple::SearchStateDFS*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ALL_SIMPLE_MASK: {
         auto state = reinterpret_cast<const Paths::AllSimple::PathState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ALL_SIMPLE_DFS_MASK: {
         auto state = reinterpret_cast<const Paths::AllSimple::SearchStateDFS*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ALL_SHORTEST_SIMPLE_MASK: {
         auto state = reinterpret_cast<const Paths::AllShortestSimple::PathState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ANY_TRAILS_MASK: {
         auto state = reinterpret_cast<const Paths::AnyTrails::PathState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     // case ANY_TRAILS_DIR_MASK: {
     //     auto state = reinterpret_cast<const Paths::AnyTrails::DirectionalPathState*>(paths[index][decoded_id]);
-    //     state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+    //     state->for_each(os, print_node, print_edge, begin_at_left[index][decoded_id]);
     //     break;
     // }
     case ANY_TRAILS_DFS_MASK: {
         auto state = reinterpret_cast<const Paths::AnyTrails::SearchStateDFS*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ALL_TRAILS_MASK: {
         auto state = reinterpret_cast<const Paths::AllTrails::PathState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ALL_TRAILS_DFS_MASK: {
         auto state = reinterpret_cast<const Paths::AllTrails::SearchStateDFS*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case ALL_SHORTEST_TRAILS_MASK: {
         auto state = reinterpret_cast<const Paths::AllShortestTrails::PathState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case SHORTEST_K_WALKS_MASK: {
         auto state = reinterpret_cast<const Paths::ShortestKWalks::SearchState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case SHORTEST_K_SIMPLE_MASK: {
         auto state = reinterpret_cast<const Paths::ShortestKSimple::PathState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case SHORTEST_K_TRAILS_MASK: {
         auto state = reinterpret_cast<const Paths::ShortestKTrails::PathState*>(paths[index][decoded_id]);
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case SHORTEST_K_GROUPS_SIMPLE_MASK: {
         auto state = reinterpret_cast<const Paths::ShortestKGroupsSimple::PathState*>(
             paths[index][decoded_id]
         );
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case SHORTEST_K_GROUPS_TRAILS_MASK: {
         auto state = reinterpret_cast<const Paths::ShortestKGroupsTrails::PathState*>(
             paths[index][decoded_id]
         );
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     case SHORTEST_K_GROUPS_WALKS_MASK: {
         auto state = reinterpret_cast<const Paths::ShortestKGroupsWalks::SearchState*>(
             paths[index][decoded_id]
         );
-        state->print(os, print_node, print_edge, begin_at_left[index][decoded_id]);
+        state->for_each(node_func, edge_func, begin_at_left[index][decoded_id]);
         break;
     }
     default:

--- a/src/system/path_manager.h
+++ b/src/system/path_manager.h
@@ -84,10 +84,11 @@ public:
     ObjectId set_path(const Paths::ShortestKGroupsTrails::PathState* visited_pointer, VarId path_var);
     ObjectId set_path(const Paths::ShortestKGroupsWalks::SearchState* visited_pointer, VarId path_var);
 
-    void print(std::ostream& os,
-               uint64_t path_id,
-               std::function<void(std::ostream& os, ObjectId)> print_node,
-               std::function<void(std::ostream& os, ObjectId, bool inverse)> print_edge) const;
+    void for_each(
+        uint64_t path_id,
+        std::function<void(ObjectId)> print_node,
+        std::function<void(ObjectId, bool)> print_edge
+    ) const;
 
 private:
     PathManager(uint_fast32_t max_threads);


### PR DESCRIPTION
* Back then protocol needed to create intermediate strings in order to be delivered to the drivers due to the path_manager print method
* Now path manager exposes a "for_each" method instead, that lets you apply a function for each node and edge (in the same sequence of the path)
* Now no intermediate strings are required to write data to the drivers, they are written directly to the response_ostream