### PR TITLE
fix read/write floating points

### DIFF
--- a/src/network/server/session/streaming/request/streaming_request_reader.cc
+++ b/src/network/server/session/streaming/request/streaming_request_reader.cc
@@ -69,19 +69,27 @@ int64_t StreamingRequestReader::read_int64()
 
 float StreamingRequestReader::read_float()
 {
+    static_assert(sizeof(float) == sizeof(uint32_t));
+
     check_remaining_bytes(4);
-    float value;
-    auto dst = reinterpret_cast<uint32_t*>(&value);
-    *dst = static_cast<uint32_t>(request_bytes[current_pos++]) << 24;
-    *dst |= static_cast<uint32_t>(request_bytes[current_pos++]) << 16;
-    *dst |= static_cast<uint32_t>(request_bytes[current_pos++]) << 8;
-    *dst |= static_cast<uint32_t>(request_bytes[current_pos++]);
-    return value;
+
+    uint32_t u = static_cast<uint32_t>(request_bytes[current_pos++]) << 24;
+    u |= static_cast<uint32_t>(request_bytes[current_pos++]) << 16;
+    u |= static_cast<uint32_t>(request_bytes[current_pos++]) << 8;
+    u |= static_cast<uint32_t>(request_bytes[current_pos++]);
+
+    float f;
+    std::memcpy(&f, &u, sizeof(float));
+
+    return f;
 }
 
 template<typename T>
 tensor::Tensor<T> StreamingRequestReader::read_tensor()
 {
+    static_assert(sizeof(float) == sizeof(uint32_t));
+    static_assert(sizeof(double) == sizeof(uint64_t));
+
     const auto size = read_size();
     const auto num_bytes = sizeof(T) * size;
     check_remaining_bytes(num_bytes);
@@ -89,21 +97,21 @@ tensor::Tensor<T> StreamingRequestReader::read_tensor()
     tensor::Tensor<T> res(size);
     for (std::size_t i = 0; i < size; ++i) {
         if constexpr (std::is_same_v<T, float>) {
-            auto dst = reinterpret_cast<uint32_t*>(res.data()) + i;
-            *dst = static_cast<uint32_t>(request_bytes[current_pos++]) << 24;
-            *dst |= static_cast<uint32_t>(request_bytes[current_pos++]) << 16;
-            *dst |= static_cast<uint32_t>(request_bytes[current_pos++]) << 8;
-            *dst |= static_cast<uint32_t>(request_bytes[current_pos++]);
+            uint32_t u = static_cast<uint32_t>(request_bytes[current_pos++]) << 24;
+            u |= static_cast<uint32_t>(request_bytes[current_pos++]) << 16;
+            u |= static_cast<uint32_t>(request_bytes[current_pos++]) << 8;
+            u |= static_cast<uint32_t>(request_bytes[current_pos++]);
+            std::memcpy(&res[i], &u, sizeof(float));
         } else if constexpr (std::is_same_v<T, double>) {
-            auto dst = reinterpret_cast<uint64_t*>(res.data()) + i;
-            *dst = static_cast<uint64_t>(request_bytes[current_pos++]) << 56;
-            *dst |= static_cast<uint64_t>(request_bytes[current_pos++]) << 48;
-            *dst |= static_cast<uint64_t>(request_bytes[current_pos++]) << 40;
-            *dst |= static_cast<uint64_t>(request_bytes[current_pos++]) << 32;
-            *dst |= static_cast<uint64_t>(request_bytes[current_pos++]) << 24;
-            *dst |= static_cast<uint64_t>(request_bytes[current_pos++]) << 16;
-            *dst |= static_cast<uint64_t>(request_bytes[current_pos++]) << 8;
-            *dst |= static_cast<uint64_t>(request_bytes[current_pos++]);
+            uint64_t u = static_cast<uint64_t>(request_bytes[current_pos++]) << 56;
+            u |= static_cast<uint64_t>(request_bytes[current_pos++]) << 48;
+            u |= static_cast<uint64_t>(request_bytes[current_pos++]) << 40;
+            u |= static_cast<uint64_t>(request_bytes[current_pos++]) << 32;
+            u |= static_cast<uint64_t>(request_bytes[current_pos++]) << 24;
+            u |= static_cast<uint64_t>(request_bytes[current_pos++]) << 16;
+            u |= static_cast<uint64_t>(request_bytes[current_pos++]) << 8;
+            u |= static_cast<uint64_t>(request_bytes[current_pos++]);
+            std::memcpy(&res[i], &u, sizeof(double));
         }
     }
     return res;

--- a/src/network/server/session/streaming/response/streaming_response_writer.cc
+++ b/src/network/server/session/streaming/response/streaming_response_writer.cc
@@ -1,7 +1,5 @@
 #include "streaming_response_writer.h"
 
-#include <sstream>
-
 #include "query/query_context.h"
 #include "system/path_manager.h"
 
@@ -173,57 +171,73 @@ void StreamingResponseWriter::write_uint8(uint8_t value)
     response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-void StreamingResponseWriter::write_float(float value_)
+void StreamingResponseWriter::write_float(float value)
 {
-    auto value = reinterpret_cast<const uint32_t*>(&value_);
+    static_assert(sizeof(float) == sizeof(uint32_t));
+
+    uint32_t u;
+    std::memcpy(&u, &value, sizeof(float));
+
     uint8_t bytes[5];
     bytes[0] = static_cast<uint8_t>(Protocol::DataType::FLOAT);
-    bytes[1] = static_cast<uint8_t>((*value >> 24) & 0xFF);
-    bytes[2] = static_cast<uint8_t>((*value >> 16) & 0xFF);
-    bytes[3] = static_cast<uint8_t>((*value >> 8) & 0xFF);
-    bytes[4] = static_cast<uint8_t>(*value & 0xFF);
+    bytes[1] = static_cast<uint8_t>((u >> 24) & 0xFF);
+    bytes[2] = static_cast<uint8_t>((u >> 16) & 0xFF);
+    bytes[3] = static_cast<uint8_t>((u >> 8) & 0xFF);
+    bytes[4] = static_cast<uint8_t>(u & 0xFF);
     response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-void StreamingResponseWriter::write_float_raw(float value_)
+void StreamingResponseWriter::write_float_raw(float value)
 {
-    auto value = reinterpret_cast<const uint32_t*>(&value_);
+    static_assert(sizeof(float) == sizeof(uint32_t));
+
+    uint32_t u;
+    std::memcpy(&u, &value, sizeof(float));
+
     uint8_t bytes[4];
-    bytes[0] = static_cast<uint8_t>((*value >> 24) & 0xFF);
-    bytes[1] = static_cast<uint8_t>((*value >> 16) & 0xFF);
-    bytes[2] = static_cast<uint8_t>((*value >> 8) & 0xFF);
-    bytes[3] = static_cast<uint8_t>(*value & 0xFF);
+    bytes[0] = static_cast<uint8_t>((u >> 24) & 0xFF);
+    bytes[1] = static_cast<uint8_t>((u >> 16) & 0xFF);
+    bytes[2] = static_cast<uint8_t>((u >> 8) & 0xFF);
+    bytes[3] = static_cast<uint8_t>(u & 0xFF);
     response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-void StreamingResponseWriter::write_double(double value_)
+void StreamingResponseWriter::write_double(double value)
 {
-    auto value = reinterpret_cast<const uint64_t*>(&value_);
+    static_assert(sizeof(double) == sizeof(uint64_t));
+
+    uint64_t u;
+    std::memcpy(&u, &value, sizeof(double));
+
     uint8_t bytes[9];
     bytes[0] = static_cast<uint8_t>(Protocol::DataType::DOUBLE);
-    bytes[1] = static_cast<uint8_t>((*value >> 56) & 0xFF);
-    bytes[2] = static_cast<uint8_t>((*value >> 48) & 0xFF);
-    bytes[3] = static_cast<uint8_t>((*value >> 40) & 0xFF);
-    bytes[4] = static_cast<uint8_t>((*value >> 32) & 0xFF);
-    bytes[5] = static_cast<uint8_t>((*value >> 24) & 0xFF);
-    bytes[6] = static_cast<uint8_t>((*value >> 16) & 0xFF);
-    bytes[7] = static_cast<uint8_t>((*value >> 8) & 0xFF);
-    bytes[8] = static_cast<uint8_t>(*value & 0xFF);
+    bytes[1] = static_cast<uint8_t>((u >> 56) & 0xFF);
+    bytes[2] = static_cast<uint8_t>((u >> 48) & 0xFF);
+    bytes[3] = static_cast<uint8_t>((u >> 40) & 0xFF);
+    bytes[4] = static_cast<uint8_t>((u >> 32) & 0xFF);
+    bytes[5] = static_cast<uint8_t>((u >> 24) & 0xFF);
+    bytes[6] = static_cast<uint8_t>((u >> 16) & 0xFF);
+    bytes[7] = static_cast<uint8_t>((u >> 8) & 0xFF);
+    bytes[8] = static_cast<uint8_t>(u & 0xFF);
     response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 
-void StreamingResponseWriter::write_double_raw(double value_)
+void StreamingResponseWriter::write_double_raw(double value)
 {
-    auto value = reinterpret_cast<const uint64_t*>(&value_);
+     static_assert(sizeof(double) == sizeof(uint64_t));
+
+    uint64_t u;
+    std::memcpy(&u, &value, sizeof(double));
+
     uint8_t bytes[8];
-    bytes[0] = static_cast<uint8_t>((*value >> 56) & 0xFF);
-    bytes[1] = static_cast<uint8_t>((*value >> 48) & 0xFF);
-    bytes[2] = static_cast<uint8_t>((*value >> 40) & 0xFF);
-    bytes[3] = static_cast<uint8_t>((*value >> 32) & 0xFF);
-    bytes[4] = static_cast<uint8_t>((*value >> 24) & 0xFF);
-    bytes[5] = static_cast<uint8_t>((*value >> 16) & 0xFF);
-    bytes[6] = static_cast<uint8_t>((*value >> 8) & 0xFF);
-    bytes[7] = static_cast<uint8_t>(*value & 0xFF);
+    bytes[0] = static_cast<uint8_t>((u >> 56) & 0xFF);
+    bytes[1] = static_cast<uint8_t>((u >> 48) & 0xFF);
+    bytes[2] = static_cast<uint8_t>((u >> 40) & 0xFF);
+    bytes[3] = static_cast<uint8_t>((u >> 32) & 0xFF);
+    bytes[4] = static_cast<uint8_t>((u >> 24) & 0xFF);
+    bytes[5] = static_cast<uint8_t>((u >> 16) & 0xFF);
+    bytes[6] = static_cast<uint8_t>((u >> 8) & 0xFF);
+    bytes[7] = static_cast<uint8_t>(u & 0xFF);
     response_ostream.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
 }
 


### PR DESCRIPTION
* Fixed strict aliasing rules issues with floating points at request reader / response writer
* See more: https://en.cppreference.com/w/cpp/language/reinterpret_cast.html