### PR TITLE
some refactor in the use of boost asio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY lib)
 
 # Uncomment to disable CLI
 # add_definitions(-DNO_MDB_CLI)
+add_definitions(-DBOOST_ASIO_NO_DEPRECATED)
 
 if(APPLE)
     message("https://cmake.org/cmake/help/latest/variable/APPLE.html?highlight=apple")

--- a/src/network/server/listener.cc
+++ b/src/network/server/listener.cc
@@ -1,76 +1,73 @@
 #include "listener.h"
 
+#include "misc/fatal_error.h"
 #include "misc/logger.h"
-#include "network/server/protocol.h"
 #include "network/server/session/session_dispatcher.h"
 
 using namespace MDBServer;
 using namespace boost;
 
-
-Listener::Listener(Server&                 server,
-                   asio::io_context&       io_context,
-                   asio::ip::tcp::endpoint endpoint,
-                   std::chrono::seconds    query_timeout
+Listener::Listener(
+    Server& server,
+    asio::io_context& io_context,
+    asio::ip::tcp::endpoint endpoint,
+    std::chrono::seconds query_timeout
 ) :
-    server        (server),
-    io_context    (io_context),
-    acceptor      (io_context),
-    endpoint      (endpoint),
-    query_timeout (query_timeout)
+    server(server),
+    io_context(io_context),
+    acceptor(io_context),
+    endpoint(endpoint),
+    query_timeout(query_timeout)
 {
     boost::system::error_code ec;
 
     // Open the acceptor
-    (void) acceptor.open(endpoint.protocol(), ec);
+    acceptor.open(endpoint.protocol(), ec);
     if (ec) {
         fail(ec, "open");
     }
 
     // Allow address reuse
-    (void) acceptor.set_option(asio::socket_base::reuse_address(true), ec);
+    acceptor.set_option(asio::socket_base::reuse_address(true), ec);
     if (ec) {
         fail(ec, "set options");
     }
 
     // Bind to the server address
-    (void) acceptor.bind(endpoint, ec);
+    acceptor.bind(endpoint, ec);
     if (ec) {
         fail(ec, "bind");
     }
 
     // Start listening for connections
-    (void) acceptor.listen(asio::socket_base::max_listen_connections, ec);
+    acceptor.listen(asio::socket_base::max_listen_connections, ec);
     if (ec) {
         fail(ec, "listen");
     }
 }
 
-
-void Listener::run() {
-    acceptor.async_accept(
-        [&](const boost::system::error_code& ec, asio::ip::tcp::socket socket) {
-            // A new connection is accepted
-            logger(Category::Debug) << "New client connected";
-            if (!ec) {
-                // Disable Nagle's Algorithm to reduce latency, as our protocol may flush many small
-                // messages when answering requests
-                socket.set_option(asio::ip::tcp::no_delay(true));
-                std::make_shared<SessionDispatcher>(server, std::move(socket), query_timeout)->run();
-            }
-
-            // Accept another connection
-            run();
+void Listener::run()
+{
+    acceptor.async_accept([&](const boost::system::error_code& ec, asio::ip::tcp::socket socket) {
+        // A new connection is accepted
+        logger(Category::Debug) << "New client connected";
+        if (!ec) {
+            // Disable Nagle's Algorithm to reduce latency, as our protocol may flush many small
+            // messages when answering requests
+            socket.set_option(asio::ip::tcp::no_delay(true));
+            std::make_shared<SessionDispatcher>(server, std::move(socket), query_timeout)->run();
         }
-    );
+
+        // Accept another connection
+        run();
+    });
 }
 
-
-void Listener::fail(const boost::system::error_code& ec, char const* what) const {
+void Listener::fail(const boost::system::error_code& ec, char const* what) const
+{
     if (ec == boost::asio::error::address_in_use) {
-        logger(Category::Error) << "Port " << endpoint.port() << " already in use, try using a different port";
+        FATAL_ERROR("Port ", endpoint.port(), " already in use, try using a different port");
     } else {
-        logger(Category::Error) << "MillenniumDB::Listener error while trying to " << what << ": " << ec.message();
+        FATAL_ERROR("MillenniumDB::Listener error while trying to ", what, ": ", ec.message());
     }
-    std::exit(ec.value());
 }

--- a/src/network/server/listener.h
+++ b/src/network/server/listener.h
@@ -8,16 +8,18 @@ namespace MDBServer {
 
 class Listener {
 public:
-    Server&                        server;
-    boost::asio::io_context&       io_context;
+    Server& server;
+    boost::asio::io_context& io_context;
     boost::asio::ip::tcp::acceptor acceptor;
     boost::asio::ip::tcp::endpoint endpoint;
-    std::chrono::seconds           query_timeout;
+    std::chrono::seconds query_timeout;
 
-    explicit Listener(Server&                        server,
-                      boost::asio::io_context&       io_context,
-                      boost::asio::ip::tcp::endpoint endpoint,
-                      std::chrono::seconds           query_timeout);
+    explicit Listener(
+        Server& server,
+        boost::asio::io_context& io_context,
+        boost::asio::ip::tcp::endpoint endpoint,
+        std::chrono::seconds query_timeout
+    );
 
     void run();
 

--- a/src/network/server/server.cc
+++ b/src/network/server/server.cc
@@ -7,6 +7,7 @@
 
 #include <boost/beast.hpp>
 
+#include "misc/fatal_error.h"
 #include "misc/logger.h"
 #include "network/server/listener.h"
 #include "network/server/protocol.h"
@@ -238,8 +239,28 @@ void MDBServer::Server::browser_session(tcp::socket&& socket)
 
 void Server::browser_listener(asio::io_context* browser_io_context, int port)
 {
-    // Start the acceptor and listen for connections, dispatching them to the session
-    asio::ip::tcp::acceptor acceptor(*browser_io_context, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port));
+    asio::ip::tcp::acceptor acceptor(*browser_io_context);
+    asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), port);
+
+    boost::system::error_code ec;
+
+    acceptor.open(endpoint.protocol(), ec);
+    if (ec) {
+        FATAL_ERROR("error while trying to start browser listener: ", ec.message());
+    }
+
+    acceptor.bind(endpoint, ec);
+    if (ec) {
+        if (ec == boost::asio::error::address_in_use) {
+            FATAL_ERROR("Browser port ", endpoint.port(), " already in use, try using a different port");
+        } else {
+            FATAL_ERROR("error while trying to start browser listener: ", ec.message());
+        }
+    }
+    acceptor.listen(asio::socket_base::max_listen_connections, ec);
+    if (ec) {
+        FATAL_ERROR("error while trying to start browser listener: ", ec.message());
+    }
 
     while (true) {
         asio::ip::tcp::socket socket(*browser_io_context);

--- a/src/network/server/session/http/http_gql_session.h
+++ b/src/network/server/session/http/http_gql_session.h
@@ -1,11 +1,8 @@
 #pragma once
 
-#include <mutex>
-
 #include <boost/asio.hpp>
 #include <boost/beast.hpp>
 
-#include "network/sparql/response_type.h"
 #include "query/executor/query_executor/gql/return_executor.h"
 #include "query/executor/query_executor/query_executor.h"
 #include "query/parser/op/gql/op.h"

--- a/src/network/server/session/http/http_rdf_session.h
+++ b/src/network/server/session/http/http_rdf_session.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <mutex>
-
 #include <boost/asio.hpp>
 #include <boost/beast.hpp>
 

--- a/src/network/server/session/session_dispatcher.cc
+++ b/src/network/server/session/session_dispatcher.cc
@@ -34,7 +34,7 @@ void SessionDispatcher::run()
 
             self->read_buffer.commit(Protocol::DRIVER_PREAMBLE.size());
             auto preamble = std::string(
-                asio::buffer_cast<const char*>(self->read_buffer.data()),
+                static_cast<const char*>(self->read_buffer.data().data()),
                 Protocol::DRIVER_PREAMBLE.size()
             );
             if (preamble == Protocol::DRIVER_PREAMBLE) {

--- a/src/network/server/session/streaming/streaming_tcp_session.cc
+++ b/src/network/server/session/streaming/streaming_tcp_session.cc
@@ -61,8 +61,7 @@ void StreamingTCPSession::start_decode_chunk()
 
             // read chunk size
             self->request_buffer.commit(2);
-            const auto initial_chunk_size_bytes = asio::buffer_cast<const uint8_t*>(self->request_buffer.data(
-            ));
+            auto initial_chunk_size_bytes = static_cast<const uint8_t*>(self->request_buffer.data().data());
             const uint16_t initial_chunk_size = (static_cast<uint16_t>(initial_chunk_size_bytes[0]) << 8)
                                               | initial_chunk_size_bytes[1];
             self->request_buffer.consume(2);
@@ -125,7 +124,7 @@ void StreamingTCPSession::decode_chunk(std::size_t chunk_size)
 
             // append decoded chunk
             self->request_buffer.commit(chunk_size + 2);
-            const auto chunk_bytes = asio::buffer_cast<const uint8_t*>(self->request_buffer.data());
+            auto chunk_bytes = static_cast<const uint8_t*>(self->request_buffer.data().data());
             const auto old_size = self->decoded_chunks.size();
             self->decoded_chunks.resize(old_size + chunk_size);
             std::memcpy(self->decoded_chunks.data() + old_size, chunk_bytes, chunk_size);

--- a/src/network/server/session/streaming/streaming_websocket_session.cc
+++ b/src/network/server/session/streaming/streaming_websocket_session.cc
@@ -58,7 +58,7 @@ void StreamingWebSocketSession::start_decode_chunk()
     // read initial chunk size
     async_read_nbytes(2, [self]() {
         // read chunk size
-        const auto initial_chunk_size_bytes = asio::buffer_cast<const uint8_t*>(self->request_buffer.data());
+        auto initial_chunk_size_bytes = static_cast<const uint8_t*>(self->request_buffer.data().data());
         const uint16_t initial_chunk_size = (static_cast<uint16_t>(initial_chunk_size_bytes[0]) << 8)
                                           | initial_chunk_size_bytes[1];
         self->request_buffer.consume(2);
@@ -108,7 +108,7 @@ void StreamingWebSocketSession::decode_chunk(std::size_t chunk_size)
     // read current chunk + next chunk size
     async_read_nbytes(chunk_size + 2, [self, chunk_size]() {
         // append decoded chunk
-        const auto chunk_bytes = asio::buffer_cast<const uint8_t*>(self->request_buffer.data());
+        auto chunk_bytes = static_cast<const char*>(self->request_buffer.data().data());
         const auto old_size = self->decoded_chunks.size();
         self->decoded_chunks.resize(old_size + chunk_size);
         std::memcpy(self->decoded_chunks.data() + old_size, chunk_bytes, chunk_size);


### PR DESCRIPTION
- Now if the server can't start because browser port is used an error message is given instead of the exception thrown.
- Added -DBOOST_ASIO_NO_DEPRECATED to prevent usage of deprecated boost::asio methods.