### PR TITLE
fix: build with portable -march=x86-64-v2 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,29 @@ else()
     find_package(ICU COMPONENTS uc i18n REQUIRED)
 endif(APPLE)
 
+# Optional native-code generation for the build machine's exact CPU. On by
+# default this is OFF so the resulting binaries run on any x86-64 CPU:
+# -march=native bakes the build host's instruction set into the binary (e.g.
+# AVX-512), and a binary built that way dies with SIGILL on CPUs that lack
+# those extensions. Build with -DMDB_USE_NATIVE_ARCH=ON to trade portability
+# for peak performance on the machine you are building for.
+option(MDB_USE_NATIVE_ARCH "Compile with -march=native for the build machine's CPU" OFF)
+
+if(MDB_USE_NATIVE_ARCH)
+    set(MDB_MARCH_FLAG "-march=native")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
+    # x86-64-v2 is the conservative baseline: any x86-64 CPU from ~2009
+    # (Nehalem and later) supports it, which covers the vast majority of
+    # machines and every common cloud VM.
+    set(MDB_MARCH_FLAG "-march=x86-64-v2")
+else()
+    # Non-x86_64 targets: leave the architecture flag to the compiler's
+    # default for the target.
+    set(MDB_MARCH_FLAG "")
+endif()
+
 # Define the compiler flags
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -Wno-deprecated -pthread -march=native -funroll-loops -fno-operator-names")
+set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -Wno-deprecated -pthread ${MDB_MARCH_FLAG} -funroll-loops -fno-operator-names")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g3 -fsanitize=undefined,address -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -g0")
 


### PR DESCRIPTION
## 🐛 Fixes #109 — amd64 image dies with SIGILL on CPUs without AVX-512

### Problem

`-march=native` bakes the build host's instruction set into the binary. When the amd64 image is built on a CPU with AVX-512 (as on the Docker Hub build host), the resulting binary dies with **SIGILL** on any x86-64 CPU that lacks those extensions — which is the vast majority of them.

As reported in #109, `docker run imfd/millenniumdb mdb --version` produces no output and exits with code 132 (128 + SIGILL) on a Core i9-9980HK (SSE4.2/AVX/AVX2, no AVX-512).

### Fix

Makes the architecture flag a CMake option:

| Option | Default | Behaviour |
|---|---|---|
| `MDB_USE_NATIVE_ARCH=OFF` | ✅ **new default** | `-march=x86-64-v2` — the conservative baseline supported by every x86-64 CPU since ~2009 (Nehalem and later), so binaries run anywhere |
| `MDB_USE_NATIVE_ARCH=ON` | | `-march=native` — old behaviour, for local builds that want peak performance on the build machine |

Non-x86_64 targets (ARM etc.) are left to the compiler's default for the target.

### Verification

- ✅ CMake configures cleanly in both modes
- ✅ Default build emits `-march=x86-64-v2` (verified in `flags.make`)
- ✅ `MDB_USE_NATIVE_ARCH=ON` emits `-march=native`
- ✅ Built `mdb` with the new default on an Intel i5-1235U (no AVX-512): binary runs, prints usage, **no SIGILL**
- ✅ `objdump` confirms **0 AVX-512 (zmm) instructions** in the default build

### Impact

Small, low-risk change (one line of compiler flags + an option block). Unblocks #10 (benchmarking against QLever/Virtuoso on ordinary hardware) and makes the Docker image usable on any x86-64 host.