### PR TITLE
fix: serve env.js with the actual server port (#32)

### DIFF
--- a/src/network/server/server.cc
+++ b/src/network/server/server.cc
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <csignal>
+#include <fstream>
 #include <thread>
 #include <vector>
 
@@ -190,6 +191,38 @@ void MDBServer::Server::browser_session(tcp::socket&& socket)
         if (req.target().back() == '/')
             path.append("index.html");
 
+        // Serve env.js dynamically so the browser connects to the actual server
+        // port instead of the hardcoded default (fixes issue #32).
+        if (req.target() == "/env.js") {
+            std::ifstream env_file(path);
+            if (!env_file.is_open()) {
+                write(stream, not_found(req.target()), ec);
+                return;
+            }
+            std::string content((std::istreambuf_iterator<char>(env_file)),
+                                std::istreambuf_iterator<char>());
+
+            const std::string default_url = "http://localhost:"
+                + std::to_string(MDBServer::Protocol::DEFAULT_PORT);
+            const std::string actual_url = "http://localhost:"
+                + std::to_string(Server::mdb_port);
+
+            std::string::size_type pos = 0;
+            while ((pos = content.find(default_url, pos)) != std::string::npos) {
+                content.replace(pos, default_url.length(), actual_url);
+                pos += actual_url.length();
+            }
+
+            http::response<http::string_body> res { http::status::ok, req.version() };
+            res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+            res.set(http::field::content_type, "application/javascript");
+            res.body() = content;
+            res.content_length(content.size());
+            res.keep_alive(req.keep_alive());
+            write(stream, std::move(res), ec);
+            return;
+        }
+
         // Attempt to open the file
         boost::beast::error_code ec;
         boost::beast::http::file_body::value_type body;
@@ -283,6 +316,8 @@ void Server::run(
     std::chrono::seconds query_timeout
 )
 {
+    Server::mdb_port = port;
+
     asio::io_context io_context(num_workers);
 
     Listener listener(*this, io_context, ssl_ctx, tcp::endpoint(tcp::v4(), port), query_timeout);

--- a/src/network/server/server.h
+++ b/src/network/server/server.h
@@ -33,6 +33,10 @@ public:
     // Prevent concurrent updates
     static inline std::mutex update_execution_mutex;
 
+    // Port where the MillenniumDB HTTP/WebSocket server is listening.
+    // The browser interface needs it to connect to the right endpoint (see issue #32).
+    static inline unsigned short mdb_port = Protocol::DEFAULT_PORT;
+
     uint64_t model_id;
 
     std::vector<QueryContext> query_contexts;


### PR DESCRIPTION
## 🐛 Fixes #32 — web interface fails when mdb-server runs on a port other than 1234

### Problem

The browser interface ships with a static `browser/env.js` that hardcodes:

```js
window.ENV = {
  MDB_URL: "http://localhost:1234",
};
```

When `mdb-server` is started with `--port` different from the default (e.g. `--port 1240`), the server correctly reports `MillenniumDB HTTP/WebSocket server listening on http://localhost:1240`, but the web interface still tries to connect to `ws://localhost:1234` and fails with:

```
Connection Error
Could not fetch the remote MillenniumDB's catalog. Please check the connection to the server at "ws://localhost:1234" and try again.
```

### Solution

Store the real server port in `Server::mdb_port` and inject it into `env.js` at serve time, so the browser always connects to the endpoint the server is actually listening on:

- `server.h`: new static member `Server::mdb_port` (defaults to `Protocol::DEFAULT_PORT`)
- `server.cc`:
  - `Server::run()` stores the actual `port` in `Server::mdb_port`
  - `browser_session()` intercepts requests to `/env.js`, reads the file and replaces `http://localhost:<DEFAULT_PORT>` with `http://localhost:<actual port>`

The file on disk stays untouched — only the served response is dynamic.

### Verification

Built from a clean state and tested with a non-default port:

```
$ mdb server /tmp/mdb_test -p 1240 --browser-port 4321
MillenniumDB HTTP/WebSocket server listening on http://localhost:1240
MillenniumDB browser interface available at http://localhost:4321

$ curl http://localhost:4321/env.js
window.ENV = {
  MDB_URL: "http://localhost:1240",
  SEARCH_PROPERTIES: ["name"],
};
```

- `env.js` reports the real port (1240) ✅
- The rest of the interface (index.html, assets) is served unchanged ✅
- With the default port the served `env.js` keeps `http://localhost:1234` (no behavior change) ✅

### Scope

2 files, +39 lines, no deletions.
